### PR TITLE
Rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .build
-memcache_exporter
+memcached_exporter
 *.tar.gz
 *-stamp

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,13 @@
+The Prometheus project was started by Matt T. Proud (emeritus) and
+Julius Volz in 2012.
+
+Maintainers of this repository:
+
+* Matt Crane <mcrane@snapbug.geek.nz>
+* Tobias Schmidt <tobid@gmail.com>
+
+The following individuals have contributed code to this repository
+(listed in alphabetical order):
+
+* Matt Crane <mcrane@snapbug.geek.nz>
+* Tobias Schmidt <tobid@gmail.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+Prometheus uses GitHub to manage reviews of pull requests.
+
+* If you have a trivial fix or improvement, go ahead and create a pull
+  request, addressing (with `@...`) one or more of the maintainers
+  (see [AUTHORS.md](AUTHORS.md)) in the description of the pull request.
+
+* If you plan to do something more involved, first discuss your ideas
+  on our [mailing list](https://groups.google.com/forum/?fromgroups#!forum/prometheus-developers).
+  This will avoid unnecessary work and surely give you and us a good deal
+  of inspiration.
+
+* Relevant coding style guidelines are the [Go Code Review
+  Comments](https://code.google.com/p/go-wiki/wiki/CodeReviewComments)
+  and the _Formatting and style_ section of Peter Bourgon's [Go: Best
+  Practices for Production
+  Environments](http://peter.bourgon.org/go-in-production/#formatting-and-style).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM golang:1.4-onbuild
+FROM golang:1.6-onbuild
 MAINTAINER Matt Crane <mcrane@snapbug.geek.nz>
 
 ENTRYPOINT [ "go-wrapper", "run" ]
-CMD ["memcached:11211"]
 EXPOSE 9106

--- a/README.md
+++ b/README.md
@@ -2,53 +2,77 @@
 
 A memcached exporter for prometheus.
 
-# Building and Running
+## Building
 
-The memcache exporter exports metrics from memcached servers for
-consumption by prometheus. The servers are specified as arguments to the
-program.
+The memcached exporter exports metrics from a memcached server for
+consumption by prometheus. The server is specified as `-memcached.address` flag
+to the program (default is `localhost:11211`).
 
-By default the memcache\_exporter serves on port `9106` at `/metrics`
+By default the memcache\_exporter serves on port `0.0.0.0:9106` at `/metrics`
 
 ```
 make
-./memcache_exporter server1:11211 server2:11211 ...
+./memcached_exporter
 ```
 
 Alternatively a Dockerfile is supplied
 
 ```
-docker build -t memcache_exporter .
-docker run memcache_exporter
+docker build -t memcached_exporter .
+docker run memcached_exporter
 ```
 
-To change the server scraped using the Dockerfile method, simply create your
-own Dockerfile, and overwrite the `CMD` setting. This is also the way to enable
-logging etc.
+## Collectors
+
+The exporter collects a number of statistics from the server:
 
 ```
-FROM snapbug/memcache-exporter
-CMD ["yourserver1:yourport1", "yourserver2:yourport2", "etc:etc"]
+# HELP memcached_commands_total Total number of all requests broken down by command (get, set, etc.) and status.
+# TYPE memcached_commands_total counter
+# HELP memcached_connections_total Total number of connections opened since the server started running.
+# TYPE memcached_connections_total counter
+# HELP memcached_current_bytes Current number of bytes used to store items.
+# TYPE memcached_current_bytes gauge
+# HELP memcached_current_connections Current number of open connections.
+# TYPE memcached_current_connections gauge
+# HELP memcached_current_items Current number of items stored by this instance.
+# TYPE memcached_current_items gauge
+# HELP memcached_items_evicted_total Number of valid items removed from cache to free memory for new items.
+# TYPE memcached_items_evicted_total counter
+# HELP memcached_items_reclaimed_total Number of times an entry was stored using memory from an expired entry.
+# TYPE memcached_items_reclaimed_total counter
+# HELP memcached_items_total Total number of items stored during the life of this instance.
+# TYPE memcached_items_total counter
+# HELP memcached_limit_bytes Number of bytes this server is allowed to use for storage.
+# TYPE memcached_limit_bytes gauge
+# HELP memcached_read_bytes_total Total number of bytes read by this server from network.
+# TYPE memcached_read_bytes_total counter
+# HELP memcached_up Could the memcached server be reached.
+# TYPE memcached_up gauge
+# HELP memcached_uptime_seconds Number of seconds since the server started.
+# TYPE memcached_uptime_seconds counter
+# HELP memcached_version The version of this memcached server.
+# TYPE memcached_version gauge
+# HELP memcached_written_bytes_total Total number of bytes sent by this server to network.
+# TYPE memcached_written_bytes_total counter
 ```
 
-# Collectors
+There is also optional support to export metrics about the memcached process
+itself by setting the `-memcached.pid-file <path>` flag. If the
+memcached\_exporter process has the rights to read /proc information of the
+memcached process, then the following metrics will be exported additionally.
 
-The exporter collects a number of collections from the server:
-
-- `up`: whether the server is up.
-
-- `uptime`: how long the server has been up.
-
-- `cache`: exposes the number of cache hits and misses for
-	each server and command. For instance `{command='get',status='hits'}`
-	will say how many `get` commands resulted in a hit in the cache.
-
-- `bytes`: exposes the number of bytes read and written by each
-	server, under the label `direction`.
-
-- `removal`: exposes how many keys have been expired and evicted.
-	In the case of evicted keys it's also separated by whether they were
-	ever fetched or not.
-
-- `usage`: exposes the current and total number of connections to the cache
-	and items in the cache.
+```
+# HELP memcached_process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE memcached_process_cpu_seconds_total counter
+# HELP memcached_process_max_fds Maximum number of open file descriptors.
+# TYPE memcached_process_max_fds gauge
+# HELP memcached_process_open_fds Number of open file descriptors.
+# TYPE memcached_process_open_fds gauge
+# HELP memcached_process_resident_memory_bytes Resident memory size in bytes.
+# TYPE memcached_process_resident_memory_bytes gauge
+# HELP memcached_process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE memcached_process_start_time_seconds gauge
+# HELP memcached_process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE memcached_process_virtual_memory_bytes gauge
+```

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -178,7 +179,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(e.commands, prometheus.CounterValue, parse(s, "cmd_flush"), "flush", "hit")
 
 		// memcached includes cas operations again in cmd_set.
-		set := 0.
+		set := math.NaN()
 		if setCmd, err := strconv.ParseFloat(s["cmd_set"], 64); err == nil {
 			if cas, casErr := sum(s, "cas_misses", "cas_hits", "cas_badval"); casErr == nil {
 				set = setCmd - cas
@@ -211,7 +212,7 @@ func parse(stats map[string]string, key string) float64 {
 	v, err := strconv.ParseFloat(stats[key], 64)
 	if err != nil {
 		log.Errorf("Failed to parse %s %q: %s", key, stats[key], err)
-		v = 0
+		v = math.NaN()
 	}
 	return v
 }
@@ -221,7 +222,7 @@ func sum(stats map[string]string, keys ...string) (float64, error) {
 	for _, key := range keys {
 		v, err := strconv.ParseFloat(stats[key], 64)
 		if err != nil {
-			return 0, err
+			return math.NaN(), err
 		}
 		s += v
 	}

--- a/main.go
+++ b/main.go
@@ -56,8 +56,8 @@ func NewExporter(server string, timeout time.Duration) *Exporter {
 			nil,
 		),
 		uptime: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "uptime"),
-			"The uptime of the server.",
+			prometheus.BuildFQName(namespace, "", "uptime_seconds"),
+			"Number of seconds since the server started.",
 			nil,
 			nil,
 		),
@@ -105,7 +105,7 @@ func NewExporter(server string, timeout time.Duration) *Exporter {
 		),
 		commands: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "commands_total"),
-			"The cache hits/misses asdf broken down by command (get, set, etc.).",
+			"Total number of all requests broken down by command (get, set, etc.) and status.",
 			[]string{"command", "status"},
 			nil,
 		),

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/Snapbug/gomemcache/memcache"
+)
+
+func TestAcceptance(t *testing.T) {
+	done := false
+
+	// TODO(ts): Select unused port.
+	server := exec.Command("memcached")
+	go func() {
+		if err := server.Run(); err != nil && !done {
+			t.Fatal(err)
+		}
+	}()
+	defer func() {
+		if server.Process != nil {
+			server.Process.Kill()
+		}
+	}()
+
+	// TODO(ts): Select unused port and set memcached port.
+	exporter := exec.Command("./memcached_exporter")
+	go func() {
+		if err := exporter.Run(); err != nil && !done {
+			t.Fatal(err)
+		}
+	}()
+	defer func() {
+		if exporter.Process != nil {
+			exporter.Process.Kill()
+		}
+	}()
+
+	defer func() {
+		done = true
+	}()
+
+	// TODO(ts): Replace sleep with ready check loop.
+	<-time.After(100 * time.Millisecond)
+
+	client := memcache.New("localhost:11211")
+	item := &memcache.Item{Key: "foo", Value: []byte("bar")}
+	if err := client.Set(item); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Set(item); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Get("foo"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Get("qux"); err != memcache.ErrCacheMiss {
+		t.Fatal(err)
+	}
+	last, err := client.Get("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	last.Value = []byte("banana")
+	if err := client.CompareAndSwap(last); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Get("http://localhost:9106/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []string{
+		`memcached_up 1`,
+		`memcached_commands_total{command="get",status="hit"} 2`,
+		`memcached_commands_total{command="get",status="miss"} 1`,
+		`memcached_commands_total{command="set",status="hit"} 2`,
+		`memcached_commands_total{command="cas",status="hit"} 1`,
+		`memcached_current_bytes 74`,
+		`memcached_current_connections 11`,
+		`memcached_current_items 1`,
+		`memcached_items_total 3`,
+	}
+	for _, test := range tests {
+		if !bytes.Contains(body, []byte(test)) {
+			t.Errorf("want metrics to include %q, have:\n%s", test, body)
+		}
+	}
+}


### PR DESCRIPTION
* Rename from memcache to memcached to make clear these are daemon stats.
* Rename metrics to follow Prometheus naming guide lines.
* Break up bytes read/written in individual metrics.
* Break up evictions/reclaimed in individual metrics.
* Break up connections/items in individual metrics.
* Add missing set command counter.
* Add missing flush command counter.
* Add missing cas badval command counter.
* Add version metric.
* Add bytes + limit metrics.
* Add support to configure timeouts.
* Replace locking implementation with const metrics.

---

I started this rewrite before the slab metrics were added. Main motivation for the rewrite were aligning the metrics with Prometheus best practices. Main motivation for the fork were to provide native prometheus release support (https://prometheus.io/download/) for a very common application in current tech stacks.

@Snapbug as original author continues to have write access to this repo.

@Snapbug @jjneely @brian-brazil @SuperQ 

Todo:
* [x] Add tests
* [x] replace Godeps with govendor
* [x] Remove multi memcached server support
* [x] Add memcached process metrics