### PR TITLE
Adding slab metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ docker run memcached_exporter
 The exporter collects a number of statistics from the server:
 
 ```
-# HELP memcached_active_slabs_total Total number of slab classes allocated.
-# TYPE memcached_active_slabs_total gauge
 # HELP memcached_commands_total Total number of all requests broken down by command (get, set, etc.) and status.
 # TYPE memcached_commands_total counter
 # HELP memcached_connections_total Total number of connections opened since the server started running.
@@ -42,24 +40,10 @@ The exporter collects a number of statistics from the server:
 # TYPE memcached_current_connections gauge
 # HELP memcached_current_items Current number of items stored by this instance.
 # TYPE memcached_current_items gauge
-# HELP memcached_evicted_total Number of valid items removed from cache to free memory for new items.
-# TYPE memcached_evicted_total counter
-# HELP memcached_items_age_seconds Number of seconds the oldest item has been in the slab class.
-# TYPE memcached_items_age_seconds counter
-# HELP memcached_items_evicted_total Total of times an item had to be evicted from the LRU before it expired.
-# TYPE memcached_items_evicted_total gauge
-# HELP memcached_items_evicted_unfetched_total Total number of items evicted and never fetched.
-# TYPE memcached_items_evicted_unfetched_total gauge
-# HELP memcached_items_expired_unfetched_total Total number of items expired and never fetched.
-# TYPE memcached_items_expired_unfetched_total gauge
-# HELP memcached_items_number_total Total number of items currently stored in this slab class.
-# TYPE memcached_items_number_total counter
-# HELP memcached_items_outofmemory_total Total number of items for this slab class that have triggered an out of memory error.
-# TYPE memcached_items_outofmemory_total gauge
-# HELP memcached_items_reclaimed_total Total number of items reclaimed.
-# TYPE memcached_items_reclaimed_total gauge
-# HELP memcached_items_tailrepairs_total Total number of times the entries for a particular ID need repairing.
-# TYPE memcached_items_tailrepairs_total gauge
+# HELP memcached_items_evicted_total Total number of valid items removed from cache to free memory for new items.
+# TYPE memcached_items_evicted_total counter
+# HELP memcached_items_reclaimed_total Total number of times an entry was stored using memory from an expired entry.
+# TYPE memcached_items_reclaimed_total counter
 # HELP memcached_items_total Total number of items stored during the life of this instance.
 # TYPE memcached_items_total counter
 # HELP memcached_limit_bytes Number of bytes this server is allowed to use for storage.
@@ -68,26 +52,40 @@ The exporter collects a number of statistics from the server:
 # TYPE memcached_malloced_bytes gauge
 # HELP memcached_read_bytes_total Total number of bytes read by this server from network.
 # TYPE memcached_read_bytes_total counter
-# HELP memcached_reclaimed_total Number of times an entry was stored using memory from an expired entry.
-# TYPE memcached_reclaimed_total counter
-# HELP memcached_slabs_chunk_size_bytes Number of bytes allocated to each chunk within this slab class.
-# TYPE memcached_slabs_chunk_size_bytes gauge
-# HELP memcached_slabs_chunks_free_end_total Total number of free chunks at the end of the last allocated page.
-# TYPE memcached_slabs_chunks_free_end_total gauge
-# HELP memcached_slabs_chunks_free_total Total number of chunks not yet allocated items.
-# TYPE memcached_slabs_chunks_free_total gauge
-# HELP memcached_slabs_chunks_per_page_total Total number of chunks within a single page for this slab class.
-# TYPE memcached_slabs_chunks_per_page_total gauge
-# HELP memcached_slabs_chunks_total Total number of chunks allocated to this slab class.
-# TYPE memcached_slabs_chunks_total gauge
-# HELP memcached_slabs_chunks_used_total Total number of chunks allocated to an item.
-# TYPE memcached_slabs_chunks_used_total gauge
-# HELP memcached_slabs_commands_total Total number of all requests broken down by command (get, set, etc.) and status per slab.
-# TYPE memcached_slabs_commands_total counter
-# HELP memcached_slabs_mem_requested_bytes Number of bytes of memory actual items take up within a slab.
-# TYPE memcached_slabs_mem_requested_bytes gauge
-# HELP memcached_slabs_pages_total Total number of pages allocated to this slab class.
-# TYPE memcached_slabs_pages_total gauge
+# HELP memcached_slab_chunk_size_bytes Number of bytes allocated to each chunk within this slab class.
+# TYPE memcached_slab_chunk_size_bytes gauge
+# HELP memcached_slab_chunks_free Number of chunks not yet allocated items.
+# TYPE memcached_slab_chunks_free gauge
+# HELP memcached_slab_chunks_free_end Number of free chunks at the end of the last allocated page.
+# TYPE memcached_slab_chunks_free_end gauge
+# HELP memcached_slab_chunks_per_page Number of chunks within a single page for this slab class.
+# TYPE memcached_slab_chunks_per_page gauge
+# HELP memcached_slab_chunks_total Total number of chunks allocated to this slab class.
+# TYPE memcached_slab_chunks_total counter
+# HELP memcached_slab_chunks_used Number of chunks allocated to an item.
+# TYPE memcached_slab_chunks_used gauge
+# HELP memcached_slab_commands_total Total number of all requests broken down by command (get, set, etc.) and status per slab.
+# TYPE memcached_slab_commands_total counter
+# HELP memcached_slab_items_age_seconds Number of seconds the oldest item has been in the slab class.
+# TYPE memcached_slab_items_age_seconds gauge
+# HELP memcached_slab_items_evicted Number of times an item had to be evicted from the LRU before it expired.
+# TYPE memcached_slab_items_evicted gauge
+# HELP memcached_slab_items_evicted_unfetched Number of items evicted and never fetched.
+# TYPE memcached_slab_items_evicted_unfetched gauge
+# HELP memcached_slab_items_expired_unfetched Number of items expired and never fetched.
+# TYPE memcached_slab_items_expired_unfetched gauge
+# HELP memcached_slab_items_number Number of items currently stored in this slab class.
+# TYPE memcached_slab_items_number gauge
+# HELP memcached_slab_items_outofmemory Number of items for this slab class that have triggered an out of memory error.
+# TYPE memcached_slab_items_outofmemory gauge
+# HELP memcached_slab_items_reclaimed Number of items reclaimed.
+# TYPE memcached_slab_items_reclaimed gauge
+# HELP memcached_slab_items_tailrepairs Number of times the entries for a particular ID need repairing.
+# TYPE memcached_slab_items_tailrepairs gauge
+# HELP memcached_slab_mem_requested_bytes Number of bytes of memory actual items take up within a slab.
+# TYPE memcached_slab_mem_requested_bytes gauge
+# HELP memcached_slab_pages_total Total number of pages allocated to this slab class.
+# TYPE memcached_slab_pages_total counter
 # HELP memcached_up Could the memcached server be reached.
 # TYPE memcached_up gauge
 # HELP memcached_uptime_seconds Number of seconds since the server started.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ docker run memcached_exporter
 The exporter collects a number of statistics from the server:
 
 ```
+# HELP memcached_active_slabs_total Total number of slab classes allocated.
+# TYPE memcached_active_slabs_total gauge
 # HELP memcached_commands_total Total number of all requests broken down by command (get, set, etc.) and status.
 # TYPE memcached_commands_total counter
 # HELP memcached_connections_total Total number of connections opened since the server started running.
@@ -40,16 +42,52 @@ The exporter collects a number of statistics from the server:
 # TYPE memcached_current_connections gauge
 # HELP memcached_current_items Current number of items stored by this instance.
 # TYPE memcached_current_items gauge
-# HELP memcached_items_evicted_total Number of valid items removed from cache to free memory for new items.
-# TYPE memcached_items_evicted_total counter
-# HELP memcached_items_reclaimed_total Number of times an entry was stored using memory from an expired entry.
-# TYPE memcached_items_reclaimed_total counter
+# HELP memcached_evicted_total Number of valid items removed from cache to free memory for new items.
+# TYPE memcached_evicted_total counter
+# HELP memcached_items_age_seconds Number of seconds the oldest item has been in the slab class.
+# TYPE memcached_items_age_seconds counter
+# HELP memcached_items_evicted_total Total of times an item had to be evicted from the LRU before it expired.
+# TYPE memcached_items_evicted_total gauge
+# HELP memcached_items_evicted_unfetched_total Total number of items evicted and never fetched.
+# TYPE memcached_items_evicted_unfetched_total gauge
+# HELP memcached_items_expired_unfetched_total Total number of items expired and never fetched.
+# TYPE memcached_items_expired_unfetched_total gauge
+# HELP memcached_items_number_total Total number of items currently stored in this slab class.
+# TYPE memcached_items_number_total counter
+# HELP memcached_items_outofmemory_total Total number of items for this slab class that have triggered an out of memory error.
+# TYPE memcached_items_outofmemory_total gauge
+# HELP memcached_items_reclaimed_total Total number of items reclaimed.
+# TYPE memcached_items_reclaimed_total gauge
+# HELP memcached_items_tailrepairs_total Total number of times the entries for a particular ID need repairing.
+# TYPE memcached_items_tailrepairs_total gauge
 # HELP memcached_items_total Total number of items stored during the life of this instance.
 # TYPE memcached_items_total counter
 # HELP memcached_limit_bytes Number of bytes this server is allowed to use for storage.
 # TYPE memcached_limit_bytes gauge
+# HELP memcached_malloced_bytes Number of bytes of memory allocated to slab pages.
+# TYPE memcached_malloced_bytes gauge
 # HELP memcached_read_bytes_total Total number of bytes read by this server from network.
 # TYPE memcached_read_bytes_total counter
+# HELP memcached_reclaimed_total Number of times an entry was stored using memory from an expired entry.
+# TYPE memcached_reclaimed_total counter
+# HELP memcached_slabs_chunk_size_bytes Number of bytes allocated to each chunk within this slab class.
+# TYPE memcached_slabs_chunk_size_bytes gauge
+# HELP memcached_slabs_chunks_free_end_total Total number of free chunks at the end of the last allocated page.
+# TYPE memcached_slabs_chunks_free_end_total gauge
+# HELP memcached_slabs_chunks_free_total Total number of chunks not yet allocated items.
+# TYPE memcached_slabs_chunks_free_total gauge
+# HELP memcached_slabs_chunks_per_page_total Total number of chunks within a single page for this slab class.
+# TYPE memcached_slabs_chunks_per_page_total gauge
+# HELP memcached_slabs_chunks_total Total number of chunks allocated to this slab class.
+# TYPE memcached_slabs_chunks_total gauge
+# HELP memcached_slabs_chunks_used_total Total number of chunks allocated to an item.
+# TYPE memcached_slabs_chunks_used_total gauge
+# HELP memcached_slabs_commands_total Total number of all requests broken down by command (get, set, etc.) and status per slab.
+# TYPE memcached_slabs_commands_total counter
+# HELP memcached_slabs_mem_requested_bytes Number of bytes of memory actual items take up within a slab.
+# TYPE memcached_slabs_mem_requested_bytes gauge
+# HELP memcached_slabs_pages_total Total number of pages allocated to this slab class.
+# TYPE memcached_slabs_pages_total gauge
 # HELP memcached_up Could the memcached server be reached.
 # TYPE memcached_up gauge
 # HELP memcached_uptime_seconds Number of seconds since the server started.

--- a/README.md
+++ b/README.md
@@ -60,14 +60,16 @@ The exporter collects a number of statistics from the server:
 # TYPE memcached_slab_chunks_free_end gauge
 # HELP memcached_slab_chunks_per_page Number of chunks within a single page for this slab class.
 # TYPE memcached_slab_chunks_per_page gauge
-# HELP memcached_slab_chunks_total Total number of chunks allocated to this slab class.
-# TYPE memcached_slab_chunks_total counter
 # HELP memcached_slab_chunks_used Number of chunks allocated to an item.
 # TYPE memcached_slab_chunks_used gauge
 # HELP memcached_slab_commands_total Total number of all requests broken down by command (get, set, etc.) and status per slab.
 # TYPE memcached_slab_commands_total counter
+# HELP memcached_slab_current_chunks Number of chunks allocated to this slab class.
+# TYPE memcached_slab_current_chunks gauge
 # HELP memcached_slab_current_items Number of items currently stored in this slab class.
 # TYPE memcached_slab_current_items gauge
+# HELP memcached_slab_current_pages Number of pages allocated to this slab class.
+# TYPE memcached_slab_current_pages gauge
 # HELP memcached_slab_items_age_seconds Number of seconds the oldest item has been in the slab class.
 # TYPE memcached_slab_items_age_seconds counter
 # HELP memcached_slab_items_crawler_reclaimed_total Total number of items freed by the LRU Crawler.
@@ -90,8 +92,6 @@ The exporter collects a number of statistics from the server:
 # TYPE memcached_slab_items_tailrepairs_total counter
 # HELP memcached_slab_mem_requested_bytes Number of bytes of memory actual items take up within a slab.
 # TYPE memcached_slab_mem_requested_bytes gauge
-# HELP memcached_slab_pages_total Total number of pages allocated to this slab class.
-# TYPE memcached_slab_pages_total counter
 # HELP memcached_up Could the memcached server be reached.
 # TYPE memcached_up gauge
 # HELP memcached_uptime_seconds Number of seconds since the server started.

--- a/README.md
+++ b/README.md
@@ -66,22 +66,28 @@ The exporter collects a number of statistics from the server:
 # TYPE memcached_slab_chunks_used gauge
 # HELP memcached_slab_commands_total Total number of all requests broken down by command (get, set, etc.) and status per slab.
 # TYPE memcached_slab_commands_total counter
+# HELP memcached_slab_current_items Number of items currently stored in this slab class.
+# TYPE memcached_slab_current_items gauge
 # HELP memcached_slab_items_age_seconds Number of seconds the oldest item has been in the slab class.
-# TYPE memcached_slab_items_age_seconds gauge
-# HELP memcached_slab_items_evicted Number of times an item had to be evicted from the LRU before it expired.
-# TYPE memcached_slab_items_evicted gauge
-# HELP memcached_slab_items_evicted_unfetched Number of items evicted and never fetched.
-# TYPE memcached_slab_items_evicted_unfetched gauge
-# HELP memcached_slab_items_expired_unfetched Number of items expired and never fetched.
-# TYPE memcached_slab_items_expired_unfetched gauge
-# HELP memcached_slab_items_number Number of items currently stored in this slab class.
-# TYPE memcached_slab_items_number gauge
-# HELP memcached_slab_items_outofmemory Number of items for this slab class that have triggered an out of memory error.
-# TYPE memcached_slab_items_outofmemory gauge
-# HELP memcached_slab_items_reclaimed Number of items reclaimed.
-# TYPE memcached_slab_items_reclaimed gauge
-# HELP memcached_slab_items_tailrepairs Number of times the entries for a particular ID need repairing.
-# TYPE memcached_slab_items_tailrepairs gauge
+# TYPE memcached_slab_items_age_seconds counter
+# HELP memcached_slab_items_crawler_reclaimed_total Total number of items freed by the LRU Crawler.
+# TYPE memcached_slab_items_crawler_reclaimed_total counter
+# HELP memcached_slab_items_evicted_nonzero_total Total number of times an item which had an explicit expire time set had to be evicted from the LRU before it expired.
+# TYPE memcached_slab_items_evicted_nonzero_total counter
+# HELP memcached_slab_items_evicted_time_seconds Seconds since the last access for the most recent item evicted from this class.
+# TYPE memcached_slab_items_evicted_time_seconds counter
+# HELP memcached_slab_items_evicted_total Total number of times an item had to be evicted from the LRU before it expired.
+# TYPE memcached_slab_items_evicted_total counter
+# HELP memcached_slab_items_evicted_unfetched_total Total nmber of items evicted and never fetched.
+# TYPE memcached_slab_items_evicted_unfetched_total counter
+# HELP memcached_slab_items_expired_unfetched_total Total number of valid items evicted from the LRU which were never touched after being set.
+# TYPE memcached_slab_items_expired_unfetched_total counter
+# HELP memcached_slab_items_outofmemory_total Total number of items for this slab class that have triggered an out of memory error.
+# TYPE memcached_slab_items_outofmemory_total counter
+# HELP memcached_slab_items_reclaimed_total Total number of items reclaimed.
+# TYPE memcached_slab_items_reclaimed_total counter
+# HELP memcached_slab_items_tailrepairs_total Total number of times the entries for a particular ID need repairing.
+# TYPE memcached_slab_items_tailrepairs_total counter
 # HELP memcached_slab_mem_requested_bytes Number of bytes of memory actual items take up within a slab.
 # TYPE memcached_slab_mem_requested_bytes gauge
 # HELP memcached_slab_pages_total Total number of pages allocated to this slab class.

--- a/main.go
+++ b/main.go
@@ -55,8 +55,8 @@ type Exporter struct {
 	itemsTailrepairs      *prometheus.Desc
 	slabsChunkSize        *prometheus.Desc
 	slabsChunksPerPage    *prometheus.Desc
-	slabsPagesTotal       *prometheus.Desc
-	slabsChunksTotal      *prometheus.Desc
+	slabsCurrentPages     *prometheus.Desc
+	slabsCurrentChunks    *prometheus.Desc
 	slabsChunksUsed       *prometheus.Desc
 	slabsChunksFree       *prometheus.Desc
 	slabsChunksFreeEnd    *prometheus.Desc
@@ -239,15 +239,15 @@ func NewExporter(server string, timeout time.Duration) *Exporter {
 			[]string{"slab"},
 			nil,
 		),
-		slabsPagesTotal: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "slab", "pages_total"),
-			"Total number of pages allocated to this slab class.",
+		slabsCurrentPages: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "slab", "current_pages"),
+			"Number of pages allocated to this slab class.",
 			[]string{"slab"},
 			nil,
 		),
-		slabsChunksTotal: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "slab", "chunks_total"),
-			"Total number of chunks allocated to this slab class.",
+		slabsCurrentChunks: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "slab", "current_chunks"),
+			"Number of chunks allocated to this slab class.",
 			[]string{"slab"},
 			nil,
 		),
@@ -316,8 +316,8 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.itemsExpiredUnfetched
 	ch <- e.slabsChunkSize
 	ch <- e.slabsChunksPerPage
-	ch <- e.slabsPagesTotal
-	ch <- e.slabsChunksTotal
+	ch <- e.slabsCurrentPages
+	ch <- e.slabsCurrentChunks
 	ch <- e.slabsChunksUsed
 	ch <- e.slabsChunksFree
 	ch <- e.slabsChunksFreeEnd
@@ -414,8 +414,8 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 			ch <- prometheus.MustNewConstMetric(e.slabsChunkSize, prometheus.GaugeValue, parse(v, "chunk_size"), slab)
 			ch <- prometheus.MustNewConstMetric(e.slabsChunksPerPage, prometheus.GaugeValue, parse(v, "chunks_per_page"), slab)
-			ch <- prometheus.MustNewConstMetric(e.slabsPagesTotal, prometheus.CounterValue, parse(v, "total_pages"), slab)
-			ch <- prometheus.MustNewConstMetric(e.slabsChunksTotal, prometheus.CounterValue, parse(v, "total_chunks"), slab)
+			ch <- prometheus.MustNewConstMetric(e.slabsCurrentPages, prometheus.GaugeValue, parse(v, "total_pages"), slab)
+			ch <- prometheus.MustNewConstMetric(e.slabsCurrentChunks, prometheus.GaugeValue, parse(v, "total_chunks"), slab)
 			ch <- prometheus.MustNewConstMetric(e.slabsChunksUsed, prometheus.GaugeValue, parse(v, "used_chunks"), slab)
 			ch <- prometheus.MustNewConstMetric(e.slabsChunksFree, prometheus.GaugeValue, parse(v, "free_chunks"), slab)
 			ch <- prometheus.MustNewConstMetric(e.slabsChunksFreeEnd, prometheus.GaugeValue, parse(v, "free_chunks_end"), slab)

--- a/main.go
+++ b/main.go
@@ -41,7 +41,6 @@ type Exporter struct {
 	itemsTotal            *prometheus.Desc
 	evictions             *prometheus.Desc
 	reclaimed             *prometheus.Desc
-	active_slabs          *prometheus.Desc
 	malloced              *prometheus.Desc
 	itemsNumber           *prometheus.Desc
 	itemsAge              *prometheus.Desc
@@ -142,20 +141,14 @@ func NewExporter(server string, timeout time.Duration) *Exporter {
 			nil,
 		),
 		evictions: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "evicted_total"),
-			"Number of valid items removed from cache to free memory for new items.",
+			prometheus.BuildFQName(namespace, "", "items_evicted_total"),
+			"Total number of valid items removed from cache to free memory for new items.",
 			nil,
 			nil,
 		),
 		reclaimed: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "reclaimed_total"),
-			"Number of times an entry was stored using memory from an expired entry.",
-			nil,
-			nil,
-		),
-		active_slabs: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "active_slabs_total"),
-			"Total number of slab classes allocated.",
+			prometheus.BuildFQName(namespace, "", "items_reclaimed_total"),
+			"Total number of times an entry was stored using memory from an expired entry.",
 			nil,
 			nil,
 		),
@@ -166,103 +159,103 @@ func NewExporter(server string, timeout time.Duration) *Exporter {
 			nil,
 		),
 		itemsNumber: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "items_number_total"),
-			"Total number of items currently stored in this slab class.",
+			prometheus.BuildFQName(namespace, "slab", "items_number"),
+			"Number of items currently stored in this slab class.",
 			[]string{"slab"},
 			nil,
 		),
 		itemsAge: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "items_age_seconds"),
+			prometheus.BuildFQName(namespace, "slab", "items_age_seconds"),
 			"Number of seconds the oldest item has been in the slab class.",
 			[]string{"slab"},
 			nil,
 		),
 		itemsEvicted: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "items_evicted_total"),
-			"Total of times an item had to be evicted from the LRU before it expired.",
+			prometheus.BuildFQName(namespace, "slab", "items_evicted"),
+			"Number of times an item had to be evicted from the LRU before it expired.",
 			[]string{"slab"},
 			nil,
 		),
 		itemsEvictedUnfetched: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "items_evicted_unfetched_total"),
-			"Total number of items evicted and never fetched.",
+			prometheus.BuildFQName(namespace, "slab", "items_evicted_unfetched"),
+			"Number of items evicted and never fetched.",
 			[]string{"slab"},
 			nil,
 		),
 		itemsOutofmemory: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "items_outofmemory_total"),
-			"Total number of items for this slab class that have triggered an out of memory error.",
+			prometheus.BuildFQName(namespace, "slab", "items_outofmemory"),
+			"Number of items for this slab class that have triggered an out of memory error.",
 			[]string{"slab"},
 			nil,
 		),
 		itemsTailrepairs: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "items_tailrepairs_total"),
-			"Total number of times the entries for a particular ID need repairing.",
+			prometheus.BuildFQName(namespace, "slab", "items_tailrepairs"),
+			"Number of times the entries for a particular ID need repairing.",
 			[]string{"slab"},
 			nil,
 		),
 		itemsReclaimed: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "items_reclaimed_total"),
-			"Total number of items reclaimed.",
+			prometheus.BuildFQName(namespace, "slab", "items_reclaimed"),
+			"Number of items reclaimed.",
 			[]string{"slab"},
 			nil,
 		),
 		itemsExpiredUnfetched: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "items_expired_unfetched_total"),
-			"Total number of items expired and never fetched.",
+			prometheus.BuildFQName(namespace, "slab", "items_expired_unfetched"),
+			"Number of items expired and never fetched.",
 			[]string{"slab"},
 			nil,
 		),
 		slabsChunkSize: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "slabs_chunk_size_bytes"),
+			prometheus.BuildFQName(namespace, "slab", "chunk_size_bytes"),
 			"Number of bytes allocated to each chunk within this slab class.",
 			[]string{"slab"},
 			nil,
 		),
 		slabsChunksPerPage: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "slabs_chunks_per_page_total"),
-			"Total number of chunks within a single page for this slab class.",
+			prometheus.BuildFQName(namespace, "slab", "chunks_per_page"),
+			"Number of chunks within a single page for this slab class.",
 			[]string{"slab"},
 			nil,
 		),
 		slabsPagesTotal: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "slabs_pages_total"),
+			prometheus.BuildFQName(namespace, "slab", "pages_total"),
 			"Total number of pages allocated to this slab class.",
 			[]string{"slab"},
 			nil,
 		),
 		slabsChunksTotal: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "slabs_chunks_total"),
+			prometheus.BuildFQName(namespace, "slab", "chunks_total"),
 			"Total number of chunks allocated to this slab class.",
 			[]string{"slab"},
 			nil,
 		),
 		slabsChunksUsed: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "slabs_chunks_used_total"),
-			"Total number of chunks allocated to an item.",
+			prometheus.BuildFQName(namespace, "slab", "chunks_used"),
+			"Number of chunks allocated to an item.",
 			[]string{"slab"},
 			nil,
 		),
 		slabsChunksFree: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "slabs_chunks_free_total"),
-			"Total number of chunks not yet allocated items.",
+			prometheus.BuildFQName(namespace, "slab", "chunks_free"),
+			"Number of chunks not yet allocated items.",
 			[]string{"slab"},
 			nil,
 		),
 		slabsChunksFreeEnd: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "slabs_chunks_free_end_total"),
-			"Total number of free chunks at the end of the last allocated page.",
+			prometheus.BuildFQName(namespace, "slab", "chunks_free_end"),
+			"Number of free chunks at the end of the last allocated page.",
 			[]string{"slab"},
 			nil,
 		),
 		slabsMemRequested: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "slabs_mem_requested_bytes"),
+			prometheus.BuildFQName(namespace, "slab", "mem_requested_bytes"),
 			"Number of bytes of memory actual items take up within a slab.",
 			[]string{"slab"},
 			nil,
 		),
 		slabsCommands: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "slabs_commands_total"),
+			prometheus.BuildFQName(namespace, "slab", "commands_total"),
 			"Total number of all requests broken down by command (get, set, etc.) and status per slab.",
 			[]string{"slab", "command", "status"},
 			nil,
@@ -287,7 +280,6 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.itemsTotal
 	ch <- e.evictions
 	ch <- e.reclaimed
-	ch <- e.active_slabs
 	ch <- e.malloced
 	ch <- e.itemsNumber
 	ch <- e.itemsAge
@@ -358,13 +350,12 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(e.evictions, prometheus.CounterValue, parse(s, "evictions"))
 		ch <- prometheus.MustNewConstMetric(e.reclaimed, prometheus.CounterValue, parse(s, "reclaimed"))
 
-		ch <- prometheus.MustNewConstMetric(e.active_slabs, prometheus.GaugeValue, parse(s, "active_slabs"))
 		ch <- prometheus.MustNewConstMetric(e.malloced, prometheus.GaugeValue, parse(s, "total_malloced"))
 
 		for slab, u := range t.Items {
 			slab := strconv.Itoa(slab)
-			ch <- prometheus.MustNewConstMetric(e.itemsNumber, prometheus.CounterValue, parse(u, "number"), slab)
-			ch <- prometheus.MustNewConstMetric(e.itemsAge, prometheus.CounterValue, parse(u, "age"), slab)
+			ch <- prometheus.MustNewConstMetric(e.itemsNumber, prometheus.GaugeValue, parse(u, "number"), slab)
+			ch <- prometheus.MustNewConstMetric(e.itemsAge, prometheus.GaugeValue, parse(u, "age"), slab)
 			ch <- prometheus.MustNewConstMetric(e.itemsEvicted, prometheus.GaugeValue, parse(u, "evicted"), slab)
 			ch <- prometheus.MustNewConstMetric(e.itemsEvictedUnfetched, prometheus.GaugeValue, parse(u, "evicted_unfetched"), slab)
 			ch <- prometheus.MustNewConstMetric(e.itemsOutofmemory, prometheus.GaugeValue, parse(u, "outofmemory"), slab)
@@ -381,22 +372,22 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 			}
 			ch <- prometheus.MustNewConstMetric(e.slabsCommands, prometheus.CounterValue, parse(v, "cas_badval"), slab, "cas", "badval")
 
-			slab_set := math.NaN()
+			slabSet := math.NaN()
 			if slabSetCmd, err := strconv.ParseFloat(v["cmd_set"], 64); err == nil {
 				if cas, casErr := sum(s, "cas_misses", "cas_hits", "cas_badval"); casErr == nil {
-					slab_set = slabSetCmd - cas
+					slabSet = slabSetCmd - cas
 				} else {
 					log.Errorf("Failed to parse cas: %s", casErr)
 				}
 			} else {
 				log.Errorf("Failed to parse set %q: %s", v["cmd_set"], err)
 			}
-			ch <- prometheus.MustNewConstMetric(e.slabsCommands, prometheus.CounterValue, slab_set, slab, "set", "hit")
+			ch <- prometheus.MustNewConstMetric(e.slabsCommands, prometheus.CounterValue, slabSet, slab, "set", "hit")
 
 			ch <- prometheus.MustNewConstMetric(e.slabsChunkSize, prometheus.GaugeValue, parse(v, "chunk_size"), slab)
 			ch <- prometheus.MustNewConstMetric(e.slabsChunksPerPage, prometheus.GaugeValue, parse(v, "chunks_per_page"), slab)
-			ch <- prometheus.MustNewConstMetric(e.slabsPagesTotal, prometheus.GaugeValue, parse(v, "total_pages"), slab)
-			ch <- prometheus.MustNewConstMetric(e.slabsChunksTotal, prometheus.GaugeValue, parse(v, "total_chunks"), slab)
+			ch <- prometheus.MustNewConstMetric(e.slabsPagesTotal, prometheus.CounterValue, parse(v, "total_pages"), slab)
+			ch <- prometheus.MustNewConstMetric(e.slabsChunksTotal, prometheus.CounterValue, parse(v, "total_chunks"), slab)
 			ch <- prometheus.MustNewConstMetric(e.slabsChunksUsed, prometheus.GaugeValue, parse(v, "used_chunks"), slab)
 			ch <- prometheus.MustNewConstMetric(e.slabsChunksFree, prometheus.GaugeValue, parse(v, "free_chunks"), slab)
 			ch <- prometheus.MustNewConstMetric(e.slabsChunksFreeEnd, prometheus.GaugeValue, parse(v, "free_chunks_end"), slab)

--- a/main.go
+++ b/main.go
@@ -402,10 +402,10 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 			slabSet := math.NaN()
 			if slabSetCmd, err := strconv.ParseFloat(v["cmd_set"], 64); err == nil {
-				if cas, casErr := sum(s, "cas_misses", "cas_hits", "cas_badval"); casErr == nil {
-					slabSet = slabSetCmd - cas
+				if slabCas, slabCasErr := sum(v, "cas_hits", "cas_badval"); slabCasErr == nil {
+					slabSet = slabSetCmd - slabCas
 				} else {
-					log.Errorf("Failed to parse cas: %s", casErr)
+					log.Errorf("Failed to parse cas: %s", slabCasErr)
 				}
 			} else {
 				log.Errorf("Failed to parse set %q: %s", v["cmd_set"], err)

--- a/main_test.go
+++ b/main_test.go
@@ -90,10 +90,9 @@ func TestAcceptance(t *testing.T) {
 		`memcached_current_connections 11`,
 		`memcached_current_items 2`,
 		`memcached_items_total 4`,
-		`memcached_active_slabs_total 2`,
-		`memcached_items_number_total{slab="1"} 1`,
-		`memcached_slabs_commands_total{command="set",slab="1",status="hit"} 2`,
-		`memcached_slabs_commands_total{command="cas",slab="1",status="hit"} 1`,
+		`memcached_slab_items_number{slab="1"} 1`,
+		`memcached_slab_commands_total{command="set",slab="1",status="hit"} 2`,
+		`memcached_slab_commands_total{command="cas",slab="1",status="hit"} 1`,
 	}
 	for _, test := range tests {
 		if !bytes.Contains(body, []byte(test)) {

--- a/main_test.go
+++ b/main_test.go
@@ -94,7 +94,7 @@ func TestAcceptance(t *testing.T) {
 		`memcached_slab_current_items{slab="5"} 1`,
 		`memcached_slab_commands_total{command="set",slab="1",status="hit"} 2`,
 		`memcached_slab_commands_total{command="cas",slab="1",status="hit"} 1`,
-		`memcached_slab_commands_total{command="set",slab="5",status="hit"} 0`,
+		`memcached_slab_commands_total{command="set",slab="5",status="hit"} 1`,
 		`memcached_slab_commands_total{command="cas",slab="5",status="hit"} 0`,
 		`memcached_slab_mem_requested_bytes{slab="1"} 74`,
 		`memcached_slab_mem_requested_bytes{slab="5"} 200`,

--- a/main_test.go
+++ b/main_test.go
@@ -90,9 +90,14 @@ func TestAcceptance(t *testing.T) {
 		`memcached_current_connections 11`,
 		`memcached_current_items 2`,
 		`memcached_items_total 4`,
-		`memcached_slab_items_number{slab="1"} 1`,
+		`memcached_slab_current_items{slab="1"} 1`,
+		`memcached_slab_current_items{slab="5"} 1`,
 		`memcached_slab_commands_total{command="set",slab="1",status="hit"} 2`,
 		`memcached_slab_commands_total{command="cas",slab="1",status="hit"} 1`,
+		`memcached_slab_commands_total{command="set",slab="5",status="hit"} 0`,
+		`memcached_slab_commands_total{command="cas",slab="5",status="hit"} 0`,
+		`memcached_slab_mem_requested_bytes{slab="1"} 74`,
+		`memcached_slab_mem_requested_bytes{slab="5"} 200`,
 	}
 	for _, test := range tests {
 		if !bytes.Contains(body, []byte(test)) {

--- a/main_test.go
+++ b/main_test.go
@@ -96,6 +96,8 @@ func TestAcceptance(t *testing.T) {
 		`memcached_slab_commands_total{command="cas",slab="1",status="hit"} 1`,
 		`memcached_slab_commands_total{command="set",slab="5",status="hit"} 1`,
 		`memcached_slab_commands_total{command="cas",slab="5",status="hit"} 0`,
+		`memcached_slab_current_chunks{slab="1"} 10922`,
+		`memcached_slab_current_chunks{slab="5"} 4369`,
 		`memcached_slab_mem_requested_bytes{slab="1"} 74`,
 		`memcached_slab_mem_requested_bytes{slab="5"} 200`,
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -64,6 +64,10 @@ func TestAcceptance(t *testing.T) {
 	if err := client.CompareAndSwap(last); err != nil {
 		t.Fatal(err)
 	}
+	large := &memcache.Item{Key: "large", Value: []byte("Hello World this text should be 128 bytes in size so that we may test the slab functionality of memcached. Filler text here to  ")}
+	if err := client.Set(large); err != nil {
+		t.Fatal(err)
+	}
 
 	resp, err := http.Get("http://localhost:9150/metrics")
 	if err != nil {
@@ -80,12 +84,16 @@ func TestAcceptance(t *testing.T) {
 		`memcached_up 1`,
 		`memcached_commands_total{command="get",status="hit"} 2`,
 		`memcached_commands_total{command="get",status="miss"} 1`,
-		`memcached_commands_total{command="set",status="hit"} 2`,
+		`memcached_commands_total{command="set",status="hit"} 3`,
 		`memcached_commands_total{command="cas",status="hit"} 1`,
-		`memcached_current_bytes 74`,
+		`memcached_current_bytes 274`,
 		`memcached_current_connections 11`,
-		`memcached_current_items 1`,
-		`memcached_items_total 3`,
+		`memcached_current_items 2`,
+		`memcached_items_total 4`,
+		`memcached_active_slabs_total 2`,
+		`memcached_items_number_total{slab="1"} 1`,
+		`memcached_slabs_commands_total{command="set",slab="1",status="hit"} 2`,
+		`memcached_slabs_commands_total{command="cas",slab="1",status="hit"} 1`,
 	}
 	for _, test := range tests {
 		if !bytes.Contains(body, []byte(test)) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -8,9 +8,10 @@
 			"revisionTime": "2016-02-24T16:10:30-05:00"
 		},
 		{
+			"checksumSHA1": "HYhRxF8+OtEDdh4i/4WYenm/a5A=",
 			"path": "github.com/Snapbug/gomemcache/memcache",
-			"revision": "4b31ef35b5d775c9bfc986bc4e87acbbbc68ee17",
-			"revisionTime": "2015-03-20T16:22:03+13:00"
+			"revision": "704599bd0d0562c86246415c7bf94960afca9efd",
+			"revisionTime": "2016-04-21T19:29:32Z"
 		},
 		{
 			"path": "github.com/beorn7/perks/quantile",
@@ -67,5 +68,6 @@
 			"revision": "19ced1583f732e8ff9d7d84de773dc621557df99",
 			"revisionTime": "2015-11-16T22:15:20-05:00"
 		}
-	]
+	],
+	"rootPath": "memcached_exporter"
 }


### PR DESCRIPTION
This resolves #2 by porting @jjneely PR from the original exporter ([PR here](https://github.com/snapbug/memcache_exporter/pull/7)). Please note I did have to rename two metrics as they would collide with the item names being added (items_evicted_total and items_reclaimed_total). If this is an issue please let me know.