### PR TITLE
Add memcached_max_connections metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The exporter collects a number of statistics from the server:
 # TYPE memcached_limit_bytes gauge
 # HELP memcached_malloced_bytes Number of bytes of memory allocated to slab pages.
 # TYPE memcached_malloced_bytes gauge
+# HELP memcached_max_connections Maximum number of clients allowed.
+# TYPE memcached_max_connections gauge
 # HELP memcached_read_bytes_total Total number of bytes read by this server from network.
 # TYPE memcached_read_bytes_total counter
 # HELP memcached_slab_chunk_size_bytes Number of bytes allocated to each chunk within this slab class.

--- a/main_test.go
+++ b/main_test.go
@@ -91,6 +91,7 @@ func TestAcceptance(t *testing.T) {
 		`memcached_commands_total{command="cas",status="hit"} 1`,
 		`memcached_current_bytes 274`,
 		`memcached_current_connections 11`,
+		`memcached_max_connections 1024`,
 		`memcached_current_items 2`,
 		`memcached_items_total 4`,
 		`memcached_slab_current_items{slab="1"} 1`,


### PR DESCRIPTION
In order to create alerts on high connection usage, add a metric
exporting the maxconns memcached setting.

This allows to calculate the connection usage:

    memcached_current_connections / memcached_max_connections
    predict_linear(memcached_current_connections[1h], 3600) / memcached_max_connections

@SuperQ @snapbug 