### PR TITLE
Fix tests on memcached_current_connections

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -97,13 +97,15 @@ OUTER:
 	}
 
 	tests := []string{
+		// memcached_current_connections varies depending on memcached versions
+		// so it isn't practical to check for an exact value.
+		`memcached_current_connections `,
 		`memcached_up 1`,
 		`memcached_commands_total{command="get",status="hit"} 2`,
 		`memcached_commands_total{command="get",status="miss"} 1`,
 		`memcached_commands_total{command="set",status="hit"} 3`,
 		`memcached_commands_total{command="cas",status="hit"} 1`,
 		`memcached_current_bytes 262`,
-		`memcached_current_connections 11`,
 		`memcached_max_connections 1024`,
 		`memcached_current_items 2`,
 		`memcached_items_total 4`,


### PR DESCRIPTION
The tests used to pass against `memcached:1.5.4` but they are now failing against `memcached:1.5.7` which is `latest` (see [example](https://circleci.com/gh/prometheus/memcached_exporter/56)).

BTW as for haproxy_exporter, CircleCI is only running on the merge operation but not on the PR itself...

cc @grobie 