### PR TITLE
Add a counter for the conn_yield memcache metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The exporter collects a number of statistics from the server:
 # TYPE memcached_commands_total counter
 # HELP memcached_connections_total Total number of connections opened since the server started running.
 # TYPE memcached_connections_total counter
+# HELP memcached_connections_yielded_total Total number of connections yielded since the server started running due to hitting the memcache's -R limit.
+# TYPE memcached_connections_yielded_total counter
 # HELP memcached_current_bytes Current number of bytes used to store items.
 # TYPE memcached_current_bytes gauge
 # HELP memcached_current_connections Current number of open connections.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The exporter collects a number of statistics from the server:
 # TYPE memcached_commands_total counter
 # HELP memcached_connections_total Total number of connections opened since the server started running.
 # TYPE memcached_connections_total counter
-# HELP memcached_connections_yielded_total Total number of connections yielded since the server started running due to hitting the memcache's -R limit.
+# HELP memcached_connections_yielded_total Total number of connections yielded running due to hitting the memcached's -R limit.
 # TYPE memcached_connections_yielded_total counter
 # HELP memcached_current_bytes Current number of bytes used to store items.
 # TYPE memcached_current_bytes gauge

--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func NewExporter(server string, timeout time.Duration) *Exporter {
 		),
 		connsYieldedTotal: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "connections_yielded_total"),
-			"Total number of connections yielded since the server started running due to hitting the memcache's -R limit.",
+			"Total number of connections yielded running due to hitting the memcached's -R limit.",
 			nil,
 			nil,
 		),


### PR DESCRIPTION
The conn_yields metric is part of the ones returned with
the "stats" command and it is defined like this:

"""
Number of times any connection yielded to another due to hitting
 the -R limit.
"""

From the following commit it seems available since 9y ago:

https://github.com/memcached/memcached/commit/a13bf0fbeda6dbb125f06620255b3888868f711c

The value is particularly useful to understand if memcache is throttling
clients or not.

PR: #33