### PR TITLE
Retrieve the current UNIX time according to the server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ The exporter collects a number of statistics from the server:
 # TYPE memcached_slab_mem_requested_bytes gauge
 # HELP memcached_up Could the memcached server be reached.
 # TYPE memcached_up gauge
+# HELP memcached_time_seconds current UNIX time according to the server.
+# TYPE memcached_time_seconds counter
 # HELP memcached_uptime_seconds Number of seconds since the server started.
 # TYPE memcached_uptime_seconds counter
 # HELP memcached_version The version of this memcached server.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The exporter collects a number of statistics from the server:
 # HELP memcached_up Could the memcached server be reached.
 # TYPE memcached_up gauge
 # HELP memcached_time_seconds current UNIX time according to the server.
-# TYPE memcached_time_seconds counter
+# TYPE memcached_time_seconds gauge
 # HELP memcached_uptime_seconds Number of seconds since the server started.
 # TYPE memcached_uptime_seconds counter
 # HELP memcached_version The version of this memcached server.

--- a/main.go
+++ b/main.go
@@ -574,7 +574,7 @@ func (e *Exporter) parseStats(ch chan<- prometheus.Metric, stats map[net.Addr]me
 		}
 		err := firstError(
 			e.parseAndNewMetric(ch, e.uptime, prometheus.CounterValue, s, "uptime"),
-			e.parseAndNewMetric(ch, e.time, prometheus.CounterValue, s, "time"),
+			e.parseAndNewMetric(ch, e.time, prometheus.GaugeValue, s, "time"),
 			e.parseAndNewMetric(ch, e.commands, prometheus.CounterValue, s, "cas_badval", "cas", "badval"),
 			e.parseAndNewMetric(ch, e.commands, prometheus.CounterValue, s, "cmd_flush", "flush", "hit"),
 		)

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ type Exporter struct {
 
 	up                       *prometheus.Desc
 	uptime                   *prometheus.Desc
+	time                     *prometheus.Desc
 	version                  *prometheus.Desc
 	bytesRead                *prometheus.Desc
 	bytesWritten             *prometheus.Desc
@@ -115,6 +116,12 @@ func NewExporter(server string, timeout time.Duration) *Exporter {
 		uptime: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "uptime_seconds"),
 			"Number of seconds since the server started.",
+			nil,
+			nil,
+		),
+		time: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "", "time_seconds"),
+			"current UNIX time according to the server.",
 			nil,
 			nil,
 		),
@@ -444,6 +451,7 @@ func NewExporter(server string, timeout time.Duration) *Exporter {
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.up
 	ch <- e.uptime
+	ch <- e.time
 	ch <- e.version
 	ch <- e.bytesRead
 	ch <- e.bytesWritten
@@ -566,6 +574,7 @@ func (e *Exporter) parseStats(ch chan<- prometheus.Metric, stats map[net.Addr]me
 		}
 		err := firstError(
 			e.parseAndNewMetric(ch, e.uptime, prometheus.CounterValue, s, "uptime"),
+			e.parseAndNewMetric(ch, e.time, prometheus.CounterValue, s, "time"),
 			e.parseAndNewMetric(ch, e.commands, prometheus.CounterValue, s, "cas_badval", "cas", "badval"),
 			e.parseAndNewMetric(ch, e.commands, prometheus.CounterValue, s, "cmd_flush", "flush", "hit"),
 		)


### PR DESCRIPTION
As memcached is using its [internal clock](https://github.com/memcached/memcached/wiki/Performance#expiration-times-should-be-accurate) as current time, this will retrieve the `time` value of the `stats` command.
@grobie 
