### PR TITLE
Add get_flushed and get_expired status to `memcached_commands_total`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# NEXT
+
+* [ENHANCEMENT] Add get_flushed and get_expired status to `memcached_commands_total` metric #93
+
 ## 0.7.0 / 2020-07-24
 
 * [CHANGE] Switch logging to go-kit #73

--- a/main.go
+++ b/main.go
@@ -647,6 +647,8 @@ func (e *Exporter) parseStats(ch chan<- prometheus.Metric, stats map[net.Addr]me
 		err := firstError(
 			e.parseAndNewMetric(ch, e.uptime, prometheus.CounterValue, s, "uptime"),
 			e.parseAndNewMetric(ch, e.time, prometheus.GaugeValue, s, "time"),
+			e.parseAndNewMetric(ch, e.commands, prometheus.CounterValue, s, "get_flushed", "get", "flushed"),
+			e.parseAndNewMetric(ch, e.commands, prometheus.CounterValue, s, "get_expired", "get", "expired"),
 			e.parseAndNewMetric(ch, e.commands, prometheus.CounterValue, s, "cas_badval", "cas", "badval"),
 			e.parseAndNewMetric(ch, e.commands, prometheus.CounterValue, s, "cmd_flush", "flush", "hit"),
 		)


### PR DESCRIPTION
Hello,

This PR adds expired and flushed status of get commands to the memcached_commands_total metrics.


```
| get_expired           | 64u     | Number of items that have been requested  but had already expired.                  |
| get_flushed           | 64u     | Number of items that have been requested  but have been flushed via flush_all |
```