### PR TITLE
Add TLS support to the memcached exporter

### DIFF
--- a/cmd/memcached_exporter/main.go
+++ b/cmd/memcached_exporter/main.go
@@ -14,13 +14,16 @@
 package main
 
 import (
+	"crypto/tls"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	promconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
 	"github.com/prometheus/common/version"
@@ -36,6 +39,12 @@ func main() {
 		address       = kingpin.Flag("memcached.address", "Memcached server address.").Default("localhost:11211").String()
 		timeout       = kingpin.Flag("memcached.timeout", "memcached connect timeout.").Default("1s").Duration()
 		pidFile       = kingpin.Flag("memcached.pid-file", "Optional path to a file containing the memcached PID for additional metrics.").Default("").String()
+		enableTls     = kingpin.Flag("memcached.tls.enable", "Enable TLS connections to memcached").Bool()
+		certfile      = kingpin.Flag("memcached.tls.certfile", "Client certificate file.").Default("").String()
+		keyfile       = kingpin.Flag("memcached.tls.keyfile", "Client private key file.").Default("").String()
+		cafile        = kingpin.Flag("memcached.tls.cafile", "Client root CA file.").Default("").String()
+		skipVerify    = kingpin.Flag("memcached.tls.skipverify", "Skip server certificate verification").Bool()
+		serverName    = kingpin.Flag("memcached.tls.servername", "Memcached TLS certificate servername").Default("").String()
 		webConfig     = webflag.AddFlags(kingpin.CommandLine)
 		listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9150").String()
 		metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
@@ -50,8 +59,30 @@ func main() {
 	level.Info(logger).Log("msg", "Starting memcached_exporter", "version", version.Info())
 	level.Info(logger).Log("msg", "Build context", "context", version.BuildContext())
 
+	if *serverName == "" {
+		*serverName = strings.Split(*address, ":")[0]
+	}
+	var (
+		tlsConfig *tls.Config
+		err       error
+	)
+	if *enableTls {
+		tlsConfig, err = promconfig.NewTLSConfig(&promconfig.TLSConfig{
+			CertFile:           *certfile,
+			KeyFile:            *keyfile,
+			CAFile:             *cafile,
+			ServerName:         *serverName,
+			InsecureSkipVerify: *skipVerify,
+		})
+		if err != nil {
+			level.Error(logger).Log("msg", "Failed to create TLS config", "err", err)
+			os.Exit(1)
+		}
+
+	}
+
 	prometheus.MustRegister(version.NewCollector("memcached_exporter"))
-	prometheus.MustRegister(exporter.New(*address, *timeout, logger))
+	prometheus.MustRegister(exporter.New(*address, *timeout, logger, tlsConfig))
 
 	if *pidFile != "" {
 		procExporter := collectors.NewProcessCollector(collectors.ProcessCollectorOpts{


### PR DESCRIPTION
This is based on, and pending, the changes in `gomemcache` PR https://github.com/grobie/gomemcache/pull/2.

The original non-TLS behaviour is unchanged, however when `--tls.enable` is given, the net connection is created by the `crypto/tls` module instead of the `net` module.

The PR follows a similar setup to the TLS code in `amtool` and made cert/key/ca/servername/insecure-skip-verify configurable. The `ServerName` defaults to the provided address which seems a sensible default. During testing, verification of the server certificates was expecting an IP SAN even when a hostname is provided as the connection address, hence the default.