### PR TITLE
Add option to disable STATS SETTINGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Alternatively a Dockerfile is supplied:
 docker run -p 9150:9150 quay.io/prometheus/memcached-exporter:latest
 ```
 
+## mcrouter
+
+In order to use the memcached_exporter with [mcrouter](https://github.com/facebook/mcrouter) the "STATS SETTINGS" collection needs to be disabled.
+
+```sh
+./memcached_exporter --no.memcached.stats.settings
+```
+
 ## Collectors
 
 The exporter collects a number of statistics from the server:

--- a/cmd/memcached_exporter/main.go
+++ b/cmd/memcached_exporter/main.go
@@ -36,6 +36,7 @@ func main() {
 		address       = kingpin.Flag("memcached.address", "Memcached server address.").Default("localhost:11211").String()
 		timeout       = kingpin.Flag("memcached.timeout", "memcached connect timeout.").Default("1s").Duration()
 		pidFile       = kingpin.Flag("memcached.pid-file", "Optional path to a file containing the memcached PID for additional metrics.").Default("").String()
+		getSettings   = kingpin.Flag("memcached.stats.settings", "Enable collection of STATS SETTINGS.").Default("true").Bool()
 		webConfig     = webflag.AddFlags(kingpin.CommandLine)
 		listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9150").String()
 		metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
@@ -51,7 +52,7 @@ func main() {
 	level.Info(logger).Log("msg", "Build context", "context", version.BuildContext())
 
 	prometheus.MustRegister(version.NewCollector("memcached_exporter"))
-	prometheus.MustRegister(exporter.New(*address, *timeout, logger))
+	prometheus.MustRegister(exporter.New(*address, *timeout, *getSettings, logger))
 
 	if *pidFile != "" {
 		procExporter := collectors.NewProcessCollector(collectors.ProcessCollectorOpts{

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -45,7 +45,7 @@ func TestParseStatsSettings(t *testing.T) {
 			},
 		}
 		ch := make(chan prometheus.Metric, 100)
-		e := New("", 100*time.Millisecond, log.NewNopLogger())
+		e := New("", 100*time.Millisecond, true, log.NewNopLogger())
 		if err := e.parseStatsSettings(ch, statsSettings); err != nil {
 			t.Errorf("expect return error, error: %v", err)
 		}
@@ -67,7 +67,7 @@ func TestParseStatsSettings(t *testing.T) {
 			},
 		}
 		ch := make(chan prometheus.Metric, 100)
-		e := New("", 100*time.Millisecond, log.NewNopLogger())
+		e := New("", 100*time.Millisecond, true, log.NewNopLogger())
 		if err := e.parseStatsSettings(ch, statsSettings); err == nil {
 			t.Error("expect return error but not")
 		}


### PR DESCRIPTION
In order to support mcrouter, add a flag to disable the collection of
"STATS SETTINGS".

Fixes: https://github.com/prometheus/memcached_exporter/issues/113

Signed-off-by: SuperQ <superq@gmail.com>