### PR TITLE
Support multi-target

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,48 @@ To use TLS and/or basic authentication, you need to pass a configuration file
 using the `--web.config.file` parameter. The format of the file is described
 [in the exporter-toolkit repository](https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md).
 
+## Multi-target
+
+The exporter also supports the [multi-target](https://prometheus.io/docs/guides/multi-target-exporter/) pattern on the `/scrape` endpoint. Example:
+```
+curl `localhost:9150/scrape?target=memcached-host.company.com:11211
+```
+
+An example configuration using [prometheus-elasticache-sd](https://github.com/maxbrunet/prometheus-elasticache-sd):
+
+```
+scrape_configs:
+  - job_name: "memcached_exporter_targets"
+    file_sd_configs:
+    - files:
+        - /path/to/elasticache.json  # File created by service discovery
+    metrics_path: /scrape
+    relabel_configs:
+      # Filter for memcached cache nodes
+      - source_labels: [__meta_elasticache_engine]
+        regex: memcached
+        action: keep
+      # Build Memcached URL to use as target parameter for the exporter
+      - source_labels:
+          - __meta_elasticache_endpoint_address
+          - __meta_elasticache_endpoint_port
+        replacement: $1
+        separator: ':'
+        target_label: __param_target
+      # Use Redis URL as instance label
+      - source_labels: [__param_target]
+        target_label: instance
+      # Set exporter address
+      - target_label: __address__
+        replacement: memcached-exporter-service.company.com:9151
+```
+
+If you are running solely for `multi-target` start the exporter with `--memcached.address=""` to avoid attempting to connect to a non existing memcached host, example:
+
+```
+./memcached-exporter --memcached.address=""
+```
+
 [buildstatus]: https://circleci.com/gh/prometheus/memcached_exporter/tree/master.svg?style=shield
 [circleci]: https://circleci.com/gh/prometheus/memcached_exporter
 [hub]: https://hub.docker.com/r/prom/memcached-exporter/

--- a/cmd/memcached_exporter/main_test.go
+++ b/cmd/memcached_exporter/main_test.go
@@ -28,53 +28,31 @@ import (
 	"github.com/grobie/gomemcache/memcache"
 )
 
-func TestAcceptance(t *testing.T) {
-	errc := make(chan error)
-
-	addr := "localhost:11211"
-	// MEMCACHED_PORT might be set by a linked memcached docker container.
-	if env := os.Getenv("MEMCACHED_PORT"); env != "" {
-		addr = strings.TrimPrefix(env, "tcp://")
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	exporter := exec.CommandContext(ctx, "../../memcached_exporter", "--memcached.address", addr)
-	go func() {
-		defer close(errc)
-
-		if err := exporter.Run(); err != nil && errc != nil {
-			errc <- err
-		}
-	}()
-
-	defer cancel()
-
-	// Wait for the exporter to be up and running.
-OUTER:
+func waitExporterReady(t *testing.T, errorChannel chan error, address string) {
 	for {
 		timer := time.NewTimer(100 * time.Millisecond)
 		select {
 		case <-timer.C:
-			resp, err := http.Get("http://localhost:9150/")
-			if err == nil {
-				resp.Body.Close()
-				if resp.StatusCode == http.StatusOK {
-					break OUTER
-				}
+			resp, err := http.Get(address)
+			if err != nil {
+				t.Logf("error requesting the exporter: %v", err)
+				continue
 			}
-		case err := <-errc:
+			if resp.StatusCode != http.StatusOK {
+				resp.Body.Close()
+				t.Logf("unexpected exporter status code: %d", resp.StatusCode)
+				continue
+			} else {
+				return
+			}
+
+		case err := <-errorChannel:
 			t.Fatal("error running the exporter:", err)
 		}
 	}
+}
 
-	client, err := memcache.New(addr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := client.StatsReset(); err != nil {
-		t.Fatal(err)
-	}
-
+func warmUpMemcached(t *testing.T, client *memcache.Client) {
 	item := &memcache.Item{Key: "foo", Value: []byte("bar")}
 	if err := client.Set(item); err != nil {
 		t.Fatal(err)
@@ -100,6 +78,43 @@ OUTER:
 	if err := client.Set(large); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestAcceptanceSingleInstance(t *testing.T) {
+	errc := make(chan error)
+
+	addr := "localhost:11211"
+	// MEMCACHED_PORT might be set by a linked memcached docker container.
+	if env := os.Getenv("MEMCACHED_PORT"); env != "" {
+		addr = strings.TrimPrefix(env, "tcp://")
+	}
+
+	t.Logf("starting exporter")
+	ctx, cancel := context.WithCancel(context.Background())
+	exporter := exec.CommandContext(ctx, "../../memcached_exporter", "--memcached.address", addr)
+	go func() {
+		defer close(errc)
+
+		if err := exporter.Run(); err != nil && errc != nil {
+			errc <- err
+		}
+	}()
+
+	defer cancel()
+
+	// Wait for the exporter to be up and running.
+	t.Logf("waiting exporter initialization")
+	waitExporterReady(t, errc, "http://localhost:9150")
+
+	client, err := memcache.New(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.StatsReset(); err != nil {
+		t.Fatal(err)
+	}
+
+	warmUpMemcached(t, client)
 
 	stats_settings, err := client.StatsSettings()
 	if err != nil {
@@ -124,6 +139,144 @@ OUTER:
 	}
 
 	resp, err := http.Get("http://localhost:9150/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []string{
+		// memcached_current_connections varies depending on memcached versions
+		// so it isn't practical to check for an exact value.
+		`memcached_current_connections `,
+		`memcached_up 1`,
+		`memcached_commands_total{command="get",status="hit"} 2`,
+		`memcached_commands_total{command="get",status="miss"} 1`,
+		`memcached_commands_total{command="set",status="hit"} 3`,
+		`memcached_commands_total{command="cas",status="hit"} 1`,
+		`memcached_current_bytes 262`,
+		`memcached_max_connections 1024`,
+		`memcached_current_items 2`,
+		`memcached_items_total 4`,
+		`memcached_slab_current_items{slab="1"} 1`,
+		`memcached_slab_current_items{slab="5"} 1`,
+		`memcached_slab_commands_total{command="set",slab="1",status="hit"} 2`,
+		`memcached_slab_commands_total{command="cas",slab="1",status="hit"} 1`,
+		`memcached_slab_commands_total{command="set",slab="5",status="hit"} 1`,
+		`memcached_slab_commands_total{command="cas",slab="5",status="hit"} 0`,
+		`memcached_slab_current_chunks{slab="1"} 10922`,
+		`memcached_slab_current_chunks{slab="5"} 4369`,
+		`memcached_slab_mem_requested_bytes{slab="1"} 68`,
+		`memcached_slab_mem_requested_bytes{slab="5"} 194`,
+	}
+
+	if use_temp_lru == true {
+		tests = append(tests,
+			`memcached_slab_temporary_items{slab="1"}`,
+			`memcached_slab_lru_hits_total{lru="temporary",slab="5"}`,
+			`memcached_slab_temporary_items{slab="5"}`)
+	}
+
+	memcache_version_major_minor, err := strconv.ParseFloat(memcache_version[0:3], 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if memcache_version_major_minor >= 1.5 {
+		tests = append(tests,
+			`memcached_slab_lru_hits_total{lru="hot",slab="1"}`,
+			`memcached_slab_lru_hits_total{lru="cold",slab="1"}`,
+			`memcached_slab_lru_hits_total{lru="warm",slab="1"}`,
+			`memcached_slab_lru_hits_total{lru="temporary",slab="1"}`,
+			`memcached_slab_hot_items{slab="1"}`,
+			`memcached_slab_warm_items{slab="1"}`,
+			`memcached_slab_cold_items{slab="1"}`,
+			`memcached_slab_hot_age_seconds{slab="1"}`,
+			`memcached_slab_warm_age_seconds{slab="1"}`,
+			`memcached_slab_lru_hits_total{lru="hot",slab="5"}`,
+			`memcached_slab_lru_hits_total{lru="cold",slab="5"}`,
+			`memcached_slab_lru_hits_total{lru="warm",slab="5"}`,
+			`memcached_slab_hot_items{slab="5"}`,
+			`memcached_slab_warm_items{slab="5"}`,
+			`memcached_slab_cold_items{slab="5"}`,
+			`memcached_slab_hot_age_seconds{slab="5"}`,
+			`memcached_slab_warm_age_seconds{slab="5"}`)
+	}
+
+	for _, test := range tests {
+		if !bytes.Contains(body, []byte(test)) {
+			t.Errorf("want metrics to include %q, have:\n%s", test, body)
+		}
+	}
+
+	cancel()
+
+	<-errc
+}
+
+func TestAcceptanceScrapper(t *testing.T) {
+	errc := make(chan error)
+
+	addr := "localhost:11211"
+	// MEMCACHED_PORT might be set by a linked memcached docker container.
+	if env := os.Getenv("MEMCACHED_PORT"); env != "" {
+		addr = strings.TrimPrefix(env, "tcp://")
+	}
+
+	t.Logf("starting exporter")
+	ctx, cancel := context.WithCancel(context.Background())
+	exporter := exec.CommandContext(ctx, "../../memcached_exporter", "--memcached.address", "")
+	go func() {
+		defer close(errc)
+
+		if err := exporter.Run(); err != nil && errc != nil {
+			errc <- err
+		}
+	}()
+
+	defer cancel()
+
+	// Wait for the exporter to be up and running.
+	t.Logf("waiting exporter initialization")
+	waitExporterReady(t, errc, "http://localhost:9150")
+
+	client, err := memcache.New(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.StatsReset(); err != nil {
+		t.Fatal(err)
+	}
+
+	warmUpMemcached(t, client)
+
+	stats_settings, err := client.StatsSettings()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	use_temp_lru := false
+	for _, t := range stats_settings {
+		if t["temp_lru"] == "true" {
+			use_temp_lru = true
+		}
+	}
+
+	stats, err := client.Stats()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	memcache_version := ""
+	for _, t := range stats {
+		memcache_version = t.Stats["version"]
+	}
+
+	resp, err := http.Get("http://localhost:9150/scrape?target=" + addr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scraper/scraper_test.go
+++ b/scraper/scraper_test.go
@@ -1,0 +1,75 @@
+// Copyright 2022 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scraper
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+)
+
+func TestHandler(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
+		s := New(1*time.Second, log.NewNopLogger())
+
+		req, err := http.NewRequest("GET", "/?target=127.0.0.1:11211", nil)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(s.Handler())
+
+		handler.ServeHTTP(rr, req)
+
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code: got %d, want: %d. body: %s",
+				status, http.StatusOK, rr.Body.String())
+		}
+
+		memcachedUpMetric := "memcached_up 1"
+
+		if body := rr.Body.String(); !strings.Contains(body, memcachedUpMetric) {
+			t.Errorf("handler could not inspect metrics. body: %s", body)
+		}
+	})
+
+	t.Run("No target", func(t *testing.T) {
+		t.Parallel()
+
+		s := New(1*time.Second, log.NewNopLogger())
+
+		req, err := http.NewRequest("GET", "/", nil)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(s.Handler())
+
+		handler.ServeHTTP(rr, req)
+
+		if status := rr.Code; status != http.StatusBadRequest {
+			t.Errorf("handler returned wrong status code: got %d, want: %d", rr.Code, http.StatusBadRequest)
+		}
+	})
+}


### PR DESCRIPTION
Adds support for [multi-target pattern](https://prometheus.io/docs/guides/multi-target-exporter/). Refers to #130 

Discussion points:
- Should we always enable the `scrapper` by default? Is this possibly a security problem?