### PR TITLE
Add TLS support

### DIFF
--- a/cmd/memcached_exporter/main.go
+++ b/cmd/memcached_exporter/main.go
@@ -14,13 +14,16 @@
 package main
 
 import (
+	"crypto/tls"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	promconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
 	"github.com/prometheus/common/version"
@@ -36,6 +39,12 @@ func main() {
 		address       = kingpin.Flag("memcached.address", "Memcached server address.").Default("localhost:11211").String()
 		timeout       = kingpin.Flag("memcached.timeout", "memcached connect timeout.").Default("1s").Duration()
 		pidFile       = kingpin.Flag("memcached.pid-file", "Optional path to a file containing the memcached PID for additional metrics.").Default("").String()
+		enableTls     = kingpin.Flag("memcached.tls.enable", "Enable TLS connections to memcached").Bool()
+		certfile      = kingpin.Flag("memcached.tls.certfile", "Client certificate file.").Default("").String()
+		keyfile       = kingpin.Flag("memcached.tls.keyfile", "Client private key file.").Default("").String()
+		cafile        = kingpin.Flag("memcached.tls.cafile", "Client root CA file.").Default("").String()
+		skipVerify    = kingpin.Flag("memcached.tls.skipverify", "Skip server certificate verification").Bool()
+		serverName    = kingpin.Flag("memcached.tls.servername", "Memcached TLS certificate servername").Default("").String()
 		webConfig     = webflag.AddFlags(kingpin.CommandLine)
 		listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9150").String()
 		metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
@@ -50,8 +59,30 @@ func main() {
 	level.Info(logger).Log("msg", "Starting memcached_exporter", "version", version.Info())
 	level.Info(logger).Log("msg", "Build context", "context", version.BuildContext())
 
+	if *serverName == "" {
+		*serverName = strings.Split(*address, ":")[0]
+	}
+	var (
+		tlsConfig *tls.Config
+		err       error
+	)
+	if *enableTls {
+		tlsConfig, err = promconfig.NewTLSConfig(&promconfig.TLSConfig{
+			CertFile:           *certfile,
+			KeyFile:            *keyfile,
+			CAFile:             *cafile,
+			ServerName:         *serverName,
+			InsecureSkipVerify: *skipVerify,
+		})
+		if err != nil {
+			level.Error(logger).Log("msg", "Failed to create TLS config", "err", err)
+			os.Exit(1)
+		}
+
+	}
+
 	prometheus.MustRegister(version.NewCollector("memcached_exporter"))
-	prometheus.MustRegister(exporter.New(*address, *timeout, logger))
+	prometheus.MustRegister(exporter.New(*address, *timeout, logger, tlsConfig))
 
 	if *pidFile != "" {
 		procExporter := collectors.NewProcessCollector(collectors.ProcessCollectorOpts{

--- a/cmd/memcached_exporter/main.go
+++ b/cmd/memcached_exporter/main.go
@@ -15,9 +15,9 @@ package main
 
 import (
 	"crypto/tls"
+	"net"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -36,18 +36,18 @@ import (
 
 func main() {
 	var (
-		address       = kingpin.Flag("memcached.address", "Memcached server address.").Default("localhost:11211").String()
-		timeout       = kingpin.Flag("memcached.timeout", "memcached connect timeout.").Default("1s").Duration()
-		pidFile       = kingpin.Flag("memcached.pid-file", "Optional path to a file containing the memcached PID for additional metrics.").Default("").String()
-		enableTls     = kingpin.Flag("memcached.tls.enable", "Enable TLS connections to memcached").Bool()
-		certfile      = kingpin.Flag("memcached.tls.certfile", "Client certificate file.").Default("").String()
-		keyfile       = kingpin.Flag("memcached.tls.keyfile", "Client private key file.").Default("").String()
-		cafile        = kingpin.Flag("memcached.tls.cafile", "Client root CA file.").Default("").String()
-		skipVerify    = kingpin.Flag("memcached.tls.skipverify", "Skip server certificate verification").Bool()
-		serverName    = kingpin.Flag("memcached.tls.servername", "Memcached TLS certificate servername").Default("").String()
-		webConfig     = webflag.AddFlags(kingpin.CommandLine)
-		listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9150").String()
-		metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
+		address            = kingpin.Flag("memcached.address", "Memcached server address.").Default("localhost:11211").String()
+		timeout            = kingpin.Flag("memcached.timeout", "memcached connect timeout.").Default("1s").Duration()
+		pidFile            = kingpin.Flag("memcached.pid-file", "Optional path to a file containing the memcached PID for additional metrics.").Default("").String()
+		enableTLS          = kingpin.Flag("memcached.tls.enable", "Enable TLS connections to memcached").Bool()
+		certFile           = kingpin.Flag("memcached.tls.cert-file", "Client certificate file.").Default("").String()
+		keyFile            = kingpin.Flag("memcached.tls.key-file", "Client private key file.").Default("").String()
+		caFile             = kingpin.Flag("memcached.tls.ca-file", "Client root CA file.").Default("").String()
+		insecureSkipVerify = kingpin.Flag("memcached.tls.insecure-skip-verify", "Skip server certificate verification").Bool()
+		serverName         = kingpin.Flag("memcached.tls.server-name", "Memcached TLS certificate servername").Default("").String()
+		webConfig          = webflag.AddFlags(kingpin.CommandLine)
+		listenAddress      = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9150").String()
+		metricsPath        = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
 	)
 	promlogConfig := &promlog.Config{}
 	flag.AddFlags(kingpin.CommandLine, promlogConfig)
@@ -59,26 +59,29 @@ func main() {
 	level.Info(logger).Log("msg", "Starting memcached_exporter", "version", version.Info())
 	level.Info(logger).Log("msg", "Build context", "context", version.BuildContext())
 
-	if *serverName == "" {
-		*serverName = strings.Split(*address, ":")[0]
-	}
 	var (
 		tlsConfig *tls.Config
 		err       error
 	)
-	if *enableTls {
+	if *serverName == "" {
+		*serverName, _, err = net.SplitHostPort(*address)
+		if err != nil {
+			level.Error(logger).Log("msg", "Error running HTTP server", "err", err)
+			os.Exit(1)
+		}
+	}
+	if *enableTLS {
 		tlsConfig, err = promconfig.NewTLSConfig(&promconfig.TLSConfig{
-			CertFile:           *certfile,
-			KeyFile:            *keyfile,
-			CAFile:             *cafile,
+			CertFile:           *certFile,
+			KeyFile:            *keyFile,
+			CAFile:             *caFile,
 			ServerName:         *serverName,
-			InsecureSkipVerify: *skipVerify,
+			InsecureSkipVerify: *insecureSkipVerify,
 		})
 		if err != nil {
 			level.Error(logger).Log("msg", "Failed to create TLS config", "err", err)
 			os.Exit(1)
 		}
-
 	}
 
 	prometheus.MustRegister(version.NewCollector("memcached_exporter"))

--- a/go.mod
+++ b/go.mod
@@ -33,3 +33,5 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/grobie/gomemcache v0.0.0-20201204163352-08d7c80fcac6 => github.com/nrhodes91/gomemcache v0.0.0-20211122122106-331774faa4ec

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/go-kit/log v0.2.1
-	github.com/grobie/gomemcache v0.0.0-20201204163352-08d7c80fcac6
+	github.com/grobie/gomemcache v0.0.0-20230213081705-239240bbc445
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/common v0.37.0
 	github.com/prometheus/exporter-toolkit v0.7.1
@@ -33,5 +33,3 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace github.com/grobie/gomemcache v0.0.0-20201204163352-08d7c80fcac6 => github.com/nrhodes91/gomemcache v0.0.0-20211122122106-331774faa4ec

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/grobie/gomemcache v0.0.0-20230213081705-239240bbc445 h1:FlKQKUYPZ5yDCN248M3R7x8yu2E3yEZ0H7aLomE4EoE=
+github.com/grobie/gomemcache v0.0.0-20230213081705-239240bbc445/go.mod h1:L69/dBlPQlWkcnU76WgcppK5e4rrxzQdi6LhLnK/ytA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -161,8 +163,6 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nrhodes91/gomemcache v0.0.0-20211122122106-331774faa4ec h1:EVYZ/aQTetQNBt3XLIb5xJabHT2KwKlpwnvfFAEI/aU=
-github.com/nrhodes91/gomemcache v0.0.0-20211122122106-331774faa4ec/go.mod h1:4JEAm/chT8VKLuiiSfnrrJsD+0TWt7djil2YgXo3HPk=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,6 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
-github.com/grobie/gomemcache v0.0.0-20201204163352-08d7c80fcac6 h1:vqwzYov9hrRoGAmy61um8mVteOCD0bEbKgXr1mmkTlI=
-github.com/grobie/gomemcache v0.0.0-20201204163352-08d7c80fcac6/go.mod h1:L69/dBlPQlWkcnU76WgcppK5e4rrxzQdi6LhLnK/ytA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -163,6 +161,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nrhodes91/gomemcache v0.0.0-20211122122106-331774faa4ec h1:EVYZ/aQTetQNBt3XLIb5xJabHT2KwKlpwnvfFAEI/aU=
+github.com/nrhodes91/gomemcache v0.0.0-20211122122106-331774faa4ec/go.mod h1:4JEAm/chT8VKLuiiSfnrrJsD+0TWt7djil2YgXo3HPk=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -14,6 +14,7 @@
 package exporter
 
 import (
+	"crypto/tls"
 	"errors"
 	"net"
 	"strconv"
@@ -36,9 +37,10 @@ var errKeyNotFound = errors.New("key not found")
 
 // Exporter collects metrics from a memcached server.
 type Exporter struct {
-	address string
-	timeout time.Duration
-	logger  log.Logger
+	address   string
+	timeout   time.Duration
+	logger    log.Logger
+	tlsConfig *tls.Config
 
 	up                       *prometheus.Desc
 	uptime                   *prometheus.Desc
@@ -127,11 +129,12 @@ type Exporter struct {
 }
 
 // New returns an initialized exporter.
-func New(server string, timeout time.Duration, logger log.Logger) *Exporter {
+func New(server string, timeout time.Duration, logger log.Logger, tlsConfig *tls.Config) *Exporter {
 	return &Exporter{
-		address: server,
-		timeout: timeout,
-		logger:  logger,
+		address:   server,
+		timeout:   timeout,
+		logger:    logger,
+		tlsConfig: tlsConfig,
 		up: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, "", "up"),
 			"Could the memcached server be reached.",
@@ -739,6 +742,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 	c.Timeout = e.timeout
+	c.TlsConfig = e.tlsConfig
 
 	up := float64(1)
 	stats, err := c.Stats()

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -45,7 +45,7 @@ func TestParseStatsSettings(t *testing.T) {
 			},
 		}
 		ch := make(chan prometheus.Metric, 100)
-		e := New("", 100*time.Millisecond, log.NewNopLogger())
+		e := New("", 100*time.Millisecond, log.NewNopLogger(), nil)
 		if err := e.parseStatsSettings(ch, statsSettings); err != nil {
 			t.Errorf("expect return error, error: %v", err)
 		}
@@ -67,7 +67,7 @@ func TestParseStatsSettings(t *testing.T) {
 			},
 		}
 		ch := make(chan prometheus.Metric, 100)
-		e := New("", 100*time.Millisecond, log.NewNopLogger())
+		e := New("", 100*time.Millisecond, log.NewNopLogger(), nil)
 		if err := e.parseStatsSettings(ch, statsSettings); err == nil {
 			t.Error("expect return error but not")
 		}


### PR DESCRIPTION
This PR continues the work of @nrhodes91 in https://github.com/prometheus/memcached_exporter/pull/125.

Addressed the review comments in the previous PR and also update the gomemcache package with the required TLS config.