### PR TITLE
Fix unix domain socket connections

### DIFF
--- a/cmd/memcached_exporter/main.go
+++ b/cmd/memcached_exporter/main.go
@@ -62,14 +62,14 @@ func main() {
 		tlsConfig *tls.Config
 		err       error
 	)
-	if *serverName == "" {
-		*serverName, _, err = net.SplitHostPort(*address)
-		if err != nil {
-			level.Error(logger).Log("msg", "Error running HTTP server", "err", err)
-			os.Exit(1)
-		}
-	}
 	if *enableTLS {
+		if *serverName == "" {
+			*serverName, _, err = net.SplitHostPort(*address)
+			if err != nil {
+				level.Error(logger).Log("msg", "Error running HTTP server", "err", err)
+				os.Exit(1)
+			}
+		}
 		tlsConfig, err = promconfig.NewTLSConfig(&promconfig.TLSConfig{
 			CertFile:           *certFile,
 			KeyFile:            *keyFile,


### PR DESCRIPTION
The TLS connection code assumes the connection address will contain a port, which is not true for unix domain sockets. This change moves the host:port splitting code so that it is only run if TLS connections are enabled.

While it is possible TLS may be enabled on a unix socket, in that case the `--memcached.tls.server-name` flag will need to be set, which will bypass the call to `SplitHostPort`.