### PR TITLE
Support building with Go 1.23.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/memcached_exporter
 
-go 1.24.0
+go 1.23.0
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
Partly revert #272. We still support building with Go 1.23.