### PR TITLE
feat: add --collector.slab flag to toggle per-slab-class metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [FEATURE] Add `--collector.slab` flag to toggle high-cardinality `memcached_slab_*` metrics #178
+
 ## 0.16.0 / 2026-04-08
 
 * [FEATURE] Export proxy mode metrics #267

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ The exporter collects a number of statistics from the server.
 
 For supported metrics see the [metrics documentation](metrics.md).
 
+The per-slab-class metrics (`memcached_slab_*`) are high-cardinality and can
+dominate the number of exported series on servers with many slab classes. They
+are enabled by default but can be turned off with `--no-collector.slab`:
+
+```sh
+./memcached_exporter --no-collector.slab
+```
+
 ## TLS and basic authentication
 
 The Memcached Exporter supports TLS and basic authentication.

--- a/cmd/memcached_exporter/main.go
+++ b/cmd/memcached_exporter/main.go
@@ -50,6 +50,7 @@ func main() {
 		webConfig          = webflag.AddFlags(kingpin.CommandLine, ":9150")
 		metricsPath        = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
 		scrapePath         = kingpin.Flag("web.scrape-path", "Path under which to receive scrape requests.").Default("/scrape").String()
+		enableSlab         = kingpin.Flag("collector.slab", "Enable per-slab-class metrics (memcached_slab_*). These are high-cardinality; disable with --no-collector.slab to reduce the number of exported series.").Default("true").Bool()
 	)
 
 	promslogConfig := &promslog.Config{}
@@ -95,7 +96,7 @@ func main() {
 	prometheus.MustRegister(versioncollector.NewCollector("memcached_exporter"))
 
 	if *address != "" {
-		prometheus.MustRegister(exporter.New(*address, *timeout, logger, tlsConfig))
+		prometheus.MustRegister(exporter.New(*address, *timeout, logger, tlsConfig, *enableSlab))
 	}
 
 	if *pidFile != "" {
@@ -107,7 +108,7 @@ func main() {
 	}
 
 	http.Handle(*metricsPath, promhttp.Handler())
-	scraper := scraper.New(*timeout, logger, tlsConfig)
+	scraper := scraper.New(*timeout, logger, tlsConfig, *enableSlab)
 	http.Handle(*scrapePath, scraper.Handler())
 
 	if *metricsPath != "/" && *metricsPath != "" {

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -36,10 +36,11 @@ var errKeyNotFound = errors.New("key not found")
 
 // Exporter collects metrics from a memcached server.
 type Exporter struct {
-	address   string
-	timeout   time.Duration
-	logger    *slog.Logger
-	tlsConfig *tls.Config
+	address    string
+	timeout    time.Duration
+	logger     *slog.Logger
+	tlsConfig  *tls.Config
+	enableSlab bool
 
 	up                       *prometheus.Desc
 	uptime                   *prometheus.Desc
@@ -147,12 +148,13 @@ type Exporter struct {
 }
 
 // New returns an initialized exporter.
-func New(server string, timeout time.Duration, logger *slog.Logger, tlsConfig *tls.Config) *Exporter {
+func New(server string, timeout time.Duration, logger *slog.Logger, tlsConfig *tls.Config, enableSlab bool) *Exporter {
 	return &Exporter{
-		address:   server,
-		timeout:   timeout,
-		logger:    logger,
-		tlsConfig: tlsConfig,
+		address:    server,
+		timeout:    timeout,
+		logger:     logger,
+		tlsConfig:  tlsConfig,
+		enableSlab: enableSlab,
 		up: prometheus.NewDesc(
 			prometheus.BuildFQName(Namespace, "", "up"),
 			"Could the memcached server be reached.",
@@ -1084,6 +1086,10 @@ func (e *Exporter) parseStats(ch chan<- prometheus.Metric, stats map[net.Addr]me
 					parseError = err
 				}
 			}
+		}
+
+		if !e.enableSlab {
+			continue
 		}
 
 		for slab, v := range t.Slabs {

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -1088,51 +1088,60 @@ func (e *Exporter) parseStats(ch chan<- prometheus.Metric, stats map[net.Addr]me
 			}
 		}
 
-		if !e.enableSlab {
-			continue
-		}
-
-		for slab, v := range t.Slabs {
-			slab := strconv.Itoa(slab)
-
-			for _, op := range []string{"get", "delete", "incr", "decr", "cas", "touch"} {
-				if err := e.parseAndNewMetric(ch, e.slabsCommands, prometheus.CounterValue, v, op+"_hits", slab, op, "hit"); err != nil {
-					parseError = err
-				}
-			}
-			if err := e.parseAndNewMetric(ch, e.slabsCommands, prometheus.CounterValue, v, "cas_badval", slab, "cas", "badval"); err != nil {
-				parseError = err
-			}
-
-			slabSetCmd, err := parse(v, "cmd_set", e.logger)
-			if err == nil {
-				if slabCas, slabCasErr := sum(v, "cas_hits", "cas_badval"); slabCasErr == nil {
-					ch <- prometheus.MustNewConstMetric(e.slabsCommands, prometheus.CounterValue, slabSetCmd-slabCas, slab, "set", "hit")
-				} else {
-					e.logger.Error("Failed to parse cas", "err", slabCasErr)
-					parseError = slabCasErr
-				}
-			} else {
-				e.logger.Error("Failed to parse set", "err", err)
-				parseError = err
-			}
-
-			err = firstError(
-				e.parseAndNewMetric(ch, e.slabsChunkSize, prometheus.GaugeValue, v, "chunk_size", slab),
-				e.parseAndNewMetric(ch, e.slabsChunksPerPage, prometheus.GaugeValue, v, "chunks_per_page", slab),
-				e.parseAndNewMetric(ch, e.slabsCurrentPages, prometheus.GaugeValue, v, "total_pages", slab),
-				e.parseAndNewMetric(ch, e.slabsCurrentChunks, prometheus.GaugeValue, v, "total_chunks", slab),
-				e.parseAndNewMetric(ch, e.slabsChunksUsed, prometheus.GaugeValue, v, "used_chunks", slab),
-				e.parseAndNewMetric(ch, e.slabsChunksFree, prometheus.GaugeValue, v, "free_chunks", slab),
-				e.parseAndNewMetric(ch, e.slabsChunksFreeEnd, prometheus.GaugeValue, v, "free_chunks_end", slab),
-				e.parseAndNewMetric(ch, e.slabsMemRequested, prometheus.GaugeValue, v, "mem_requested", slab),
-			)
-			if err != nil {
+		if e.enableSlab {
+			if err := e.collectSlabMetrics(ch, t.Slabs); err != nil {
 				parseError = err
 			}
 		}
 	}
 
+	return parseError
+}
+
+// collectSlabMetrics emits the per-slab-class metrics for a single memcached
+// instance. These are high cardinality, so they are only collected when the
+// slab collector is enabled.
+func (e *Exporter) collectSlabMetrics(ch chan<- prometheus.Metric, slabs map[int]map[string]string) error {
+	var parseError error
+	for slab, v := range slabs {
+		slab := strconv.Itoa(slab)
+
+		for _, op := range []string{"get", "delete", "incr", "decr", "cas", "touch"} {
+			if err := e.parseAndNewMetric(ch, e.slabsCommands, prometheus.CounterValue, v, op+"_hits", slab, op, "hit"); err != nil {
+				parseError = err
+			}
+		}
+		if err := e.parseAndNewMetric(ch, e.slabsCommands, prometheus.CounterValue, v, "cas_badval", slab, "cas", "badval"); err != nil {
+			parseError = err
+		}
+
+		slabSetCmd, err := parse(v, "cmd_set", e.logger)
+		if err == nil {
+			if slabCas, slabCasErr := sum(v, "cas_hits", "cas_badval"); slabCasErr == nil {
+				ch <- prometheus.MustNewConstMetric(e.slabsCommands, prometheus.CounterValue, slabSetCmd-slabCas, slab, "set", "hit")
+			} else {
+				e.logger.Error("Failed to parse cas", "err", slabCasErr)
+				parseError = slabCasErr
+			}
+		} else {
+			e.logger.Error("Failed to parse set", "err", err)
+			parseError = err
+		}
+
+		err = firstError(
+			e.parseAndNewMetric(ch, e.slabsChunkSize, prometheus.GaugeValue, v, "chunk_size", slab),
+			e.parseAndNewMetric(ch, e.slabsChunksPerPage, prometheus.GaugeValue, v, "chunks_per_page", slab),
+			e.parseAndNewMetric(ch, e.slabsCurrentPages, prometheus.GaugeValue, v, "total_pages", slab),
+			e.parseAndNewMetric(ch, e.slabsCurrentChunks, prometheus.GaugeValue, v, "total_chunks", slab),
+			e.parseAndNewMetric(ch, e.slabsChunksUsed, prometheus.GaugeValue, v, "used_chunks", slab),
+			e.parseAndNewMetric(ch, e.slabsChunksFree, prometheus.GaugeValue, v, "free_chunks", slab),
+			e.parseAndNewMetric(ch, e.slabsChunksFreeEnd, prometheus.GaugeValue, v, "free_chunks_end", slab),
+			e.parseAndNewMetric(ch, e.slabsMemRequested, prometheus.GaugeValue, v, "mem_requested", slab),
+		)
+		if err != nil {
+			parseError = err
+		}
+	}
 	return parseError
 }
 

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -15,9 +15,11 @@ package exporter
 
 import (
 	"net"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/grobie/gomemcache/memcache"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/promslog"
 )
@@ -46,7 +48,7 @@ func TestParseStatsSettings(t *testing.T) {
 			},
 		}
 		ch := make(chan prometheus.Metric, 100)
-		e := New("", 100*time.Millisecond, promslog.NewNopLogger(), nil)
+		e := New("", 100*time.Millisecond, promslog.NewNopLogger(), nil, true)
 		if err := e.parseStatsSettings(ch, statsSettings); err != nil {
 			t.Errorf("expect return error, error: %v", err)
 		}
@@ -69,7 +71,7 @@ func TestParseStatsSettings(t *testing.T) {
 			},
 		}
 		ch := make(chan prometheus.Metric, 100)
-		e := New("", 100*time.Millisecond, promslog.NewNopLogger(), nil)
+		e := New("", 100*time.Millisecond, promslog.NewNopLogger(), nil, true)
 		if err := e.parseStatsSettings(ch, statsSettings); err == nil {
 			t.Error("expect return error but not")
 		}
@@ -92,4 +94,62 @@ func TestParseTimeval(t *testing.T) {
 			t.Error("expect return error but not")
 		}
 	})
+}
+
+func TestParseStatsSlabToggle(t *testing.T) {
+	addr, err := net.ResolveIPAddr("ip4", "127.0.0.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stats := map[net.Addr]memcache.Stats{
+		addr: {
+			Stats: map[string]string{
+				"version":    "1.6.0",
+				"cmd_set":    "0",
+				"cas_misses": "0",
+				"cas_hits":   "0",
+				"cas_badval": "0",
+			},
+			Slabs: map[int]map[string]string{
+				1: {
+					"chunk_size":      "96",
+					"chunks_per_page": "10922",
+					"total_pages":     "1",
+					"total_chunks":    "10922",
+					"used_chunks":     "1",
+					"free_chunks":     "10921",
+					"free_chunks_end": "0",
+					"mem_requested":   "68",
+					"cmd_set":         "2",
+					"cas_hits":        "0",
+					"cas_badval":      "0",
+				},
+			},
+		},
+	}
+
+	countSlabMetrics := func(enableSlab bool) int {
+		e := New("", 100*time.Millisecond, promslog.NewNopLogger(), nil, enableSlab)
+		ch := make(chan prometheus.Metric, 100)
+		if err := e.parseStats(ch, stats); err != nil {
+			t.Fatalf("parseStats returned an error: %v", err)
+		}
+		close(ch)
+
+		var slabMetrics int
+		for m := range ch {
+			if strings.Contains(m.Desc().String(), "memcached_slab_") {
+				slabMetrics++
+			}
+		}
+		return slabMetrics
+	}
+
+	if got := countSlabMetrics(true); got == 0 {
+		t.Error("expected slab metrics to be exported when the slab collector is enabled, got none")
+	}
+	if got := countSlabMetrics(false); got != 0 {
+		t.Errorf("expected no slab metrics when the slab collector is disabled, got %d", got)
+	}
 }

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -25,20 +25,22 @@ import (
 )
 
 type Scraper struct {
-	logger    *slog.Logger
-	timeout   time.Duration
-	tlsConfig *tls.Config
+	logger     *slog.Logger
+	timeout    time.Duration
+	tlsConfig  *tls.Config
+	enableSlab bool
 
 	scrapeCount  prometheus.Counter
 	scrapeErrors prometheus.Counter
 }
 
-func New(timeout time.Duration, logger *slog.Logger, tlsConfig *tls.Config) *Scraper {
+func New(timeout time.Duration, logger *slog.Logger, tlsConfig *tls.Config, enableSlab bool) *Scraper {
 	logger.Debug("Started scrapper")
 	return &Scraper{
-		logger:    logger,
-		timeout:   timeout,
-		tlsConfig: tlsConfig,
+		logger:     logger,
+		timeout:    timeout,
+		tlsConfig:  tlsConfig,
+		enableSlab: enableSlab,
 		scrapeCount: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "memcached_exporter_scrapes_total",
 			Help: "Count of memcached exporter scapes.",
@@ -64,7 +66,7 @@ func (s *Scraper) Handler() http.HandlerFunc {
 			return
 		}
 
-		e := exporter.New(target, s.timeout, s.logger, s.tlsConfig)
+		e := exporter.New(target, s.timeout, s.logger, s.tlsConfig, s.enableSlab)
 		registry := prometheus.NewRegistry()
 		registry.MustRegister(e)
 

--- a/scraper/scraper_test.go
+++ b/scraper/scraper_test.go
@@ -35,7 +35,7 @@ func TestHandler(t *testing.T) {
 
 		t.Parallel()
 
-		s := New(1*time.Second, promslog.NewNopLogger(), nil)
+		s := New(1*time.Second, promslog.NewNopLogger(), nil, true)
 
 		req, err := http.NewRequest("GET", fmt.Sprintf("/?target=%s", addr), nil)
 
@@ -63,7 +63,7 @@ func TestHandler(t *testing.T) {
 	t.Run("No target", func(t *testing.T) {
 		t.Parallel()
 
-		s := New(1*time.Second, promslog.NewNopLogger(), nil)
+		s := New(1*time.Second, promslog.NewNopLogger(), nil, true)
 
 		req, err := http.NewRequest("GET", "/", nil)
 


### PR DESCRIPTION
## What this does

Adds a `--collector.slab` flag (enabled by default) that controls whether the per-slab-class metrics (`memcached_slab_*`) are exported. Operators can disable them with `--no-collector.slab`.

On servers with many slab classes, these metrics are high-cardinality and can account for the vast majority of exported series (the reporter measured ~90% of their stats budget). Turning them off lets users keep the rest of the exporter's output without paying for slab-allocator detail they don't use.

The flag naming mirrors the on/off collector toggles in the node and mysqld exporters, as suggested by @matthiasr in the issue.

## Changes

- New `--collector.slab` kingpin flag in `cmd/memcached_exporter` (default `true`, so behaviour is unchanged unless explicitly disabled).
- Plumbed an `enableSlab` field through `exporter.New` and `scraper.New`; `parseStats` skips the `memcached_slab_*` emission loop when disabled.
- Unit test (`TestParseStatsSlabToggle`) asserting slab metrics are present when enabled and absent when disabled.
- Documented the flag in `README.md` and added a `CHANGELOG.md` entry.

Fixes #178